### PR TITLE
Improve the Gradle compile line excluding Support Library

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,9 @@ assertThatBackButtonClosesTheApp();
 # Download
 
 ```gradle
-androidTestCompile 'com.schibsted.spain:barista:0.0.1'
+androidTestCompile('com.schibsted.spain:barista:0.0.1') {
+  exclude group: 'com.android.support'
+}
 ```
 
 # License


### PR DESCRIPTION
As most projects use the Support Library, if we don't exclude it from the Barista dependency, the app version and the Barista one will conflict. Excluding it from Barista at the readme showcases this issue and the solution. If someone prefer to fix the issue by another way, they will be free to remove the exclude line and do their preferred magic.