### PR TITLE
Add PermissionGranter to Barista

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,14 @@ assertDrawerIsClosed(R.id.drawer);
 assertThatBackButtonClosesTheApp();
 ```
 
+## Dealing with the runtime permissions dialog
+
+The new Marshmallow permissions system requires checking for permissions at runtime. As Espresso can't interact with the system dialog, Barista offers a way to allow permissions when needed.
+
+```java
+PermissionGranter.allowPermissionsIfNeeded(Manifest.permission.GET_ACCOUNTS);
+```
+
 # Download
 
 ```gradle

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -30,7 +30,6 @@ dependencies {
         exclude module: 'support-v4'
     }
     compile 'com.android.support.test.uiautomator:uiautomator-v18:2.1.2'
-    compile 'com.android.support:appcompat-v7:25.1.0'
 }
 
 publish {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -29,6 +29,8 @@ dependencies {
     compile('com.android.support.test.espresso:espresso-contrib:2.0') {
         exclude module: 'support-v4'
     }
+    compile 'com.android.support.test.uiautomator:uiautomator-v18:2.1.2'
+    compile 'com.android.support:appcompat-v7:25.1.0'
 }
 
 publish {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -30,6 +30,7 @@ dependencies {
         exclude module: 'support-v4'
     }
     compile 'com.android.support.test.uiautomator:uiautomator-v18:2.1.2'
+    compile 'com.android.support:support-annotations:25.1.0'
 }
 
 publish {

--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -1,1 +1,7 @@
-<manifest package="com.schibsted.spain.barista"/>
+<?xml version="1.0" encoding="utf-8"?>
+<manifest
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.schibsted.spain.barista">
+
+  <uses-sdk tools:overrideLibrary="android.support.test.uiautomator.v18"/>
+</manifest>

--- a/library/src/main/java/com/schibsted/spain/barista/permission/PermissionGranter.java
+++ b/library/src/main/java/com/schibsted/spain/barista/permission/PermissionGranter.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.pm.PackageManager;
 import android.os.Build;
 import android.support.annotation.NonNull;
+import android.support.annotation.RequiresApi;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.uiautomator.UiDevice;
 import android.support.test.uiautomator.UiObject;
@@ -14,6 +15,7 @@ import android.util.Log;
 import static android.support.test.InstrumentationRegistry.getInstrumentation;
 import static com.schibsted.spain.barista.BaristaSleepActions.sleep;
 
+@RequiresApi(18)
 public class PermissionGranter {
 
   private static final int PERMISSIONS_DIALOG_DELAY = 3000;

--- a/library/src/main/java/com/schibsted/spain/barista/permission/PermissionGranter.java
+++ b/library/src/main/java/com/schibsted/spain/barista/permission/PermissionGranter.java
@@ -11,6 +11,7 @@ import android.support.test.uiautomator.UiSelector;
 import android.support.v4.content.ContextCompat;
 
 import static android.support.test.InstrumentationRegistry.getInstrumentation;
+import static com.schibsted.spain.barista.BaristaSleepActions.sleep;
 
 public class PermissionGranter {
 
@@ -39,13 +40,5 @@ public class PermissionGranter {
   private static boolean hasNeededPermission(Context context, String permissionNeeded) {
     int permissionStatus = ContextCompat.checkSelfPermission(context, permissionNeeded);
     return permissionStatus == PackageManager.PERMISSION_GRANTED;
-  }
-
-  private static void sleep(long millis) {
-    try {
-      Thread.sleep(millis);
-    } catch (InterruptedException e) {
-      throw new RuntimeException("Cannot execute Thread.sleep()");
-    }
   }
 }

--- a/library/src/main/java/com/schibsted/spain/barista/permission/PermissionGranter.java
+++ b/library/src/main/java/com/schibsted/spain/barista/permission/PermissionGranter.java
@@ -3,12 +3,12 @@ package com.schibsted.spain.barista.permission;
 import android.content.Context;
 import android.content.pm.PackageManager;
 import android.os.Build;
+import android.support.annotation.NonNull;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.uiautomator.UiDevice;
 import android.support.test.uiautomator.UiObject;
 import android.support.test.uiautomator.UiObjectNotFoundException;
 import android.support.test.uiautomator.UiSelector;
-import android.support.v4.content.ContextCompat;
 
 import static android.support.test.InstrumentationRegistry.getInstrumentation;
 import static com.schibsted.spain.barista.BaristaSleepActions.sleep;
@@ -38,7 +38,14 @@ public class PermissionGranter {
   }
 
   private static boolean hasNeededPermission(Context context, String permissionNeeded) {
-    int permissionStatus = ContextCompat.checkSelfPermission(context, permissionNeeded);
+    int permissionStatus = checkSelfPermission(context, permissionNeeded);
     return permissionStatus == PackageManager.PERMISSION_GRANTED;
+  }
+
+  private static int checkSelfPermission(@NonNull Context context, @NonNull String permission) {
+    if (permission == null) {
+      throw new IllegalArgumentException("permission is null");
+    }
+    return context.checkPermission(permission, android.os.Process.myPid(), android.os.Process.myUid());
   }
 }

--- a/library/src/main/java/com/schibsted/spain/barista/permission/PermissionGranter.java
+++ b/library/src/main/java/com/schibsted/spain/barista/permission/PermissionGranter.java
@@ -34,7 +34,7 @@ public class PermissionGranter {
         }
       }
     } catch (UiObjectNotFoundException e) {
-      Log.e("Barista", "setup");
+      Log.e("Barista", "There is no permissions dialog to interact with");
     }
   }
 

--- a/library/src/main/java/com/schibsted/spain/barista/permission/PermissionGranter.java
+++ b/library/src/main/java/com/schibsted/spain/barista/permission/PermissionGranter.java
@@ -1,0 +1,51 @@
+package com.schibsted.spain.barista.permission;
+
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.os.Build;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.uiautomator.UiDevice;
+import android.support.test.uiautomator.UiObject;
+import android.support.test.uiautomator.UiObjectNotFoundException;
+import android.support.test.uiautomator.UiSelector;
+import android.support.v4.content.ContextCompat;
+
+import static android.support.test.InstrumentationRegistry.getInstrumentation;
+
+public class PermissionGranter {
+
+  private static final int PERMISSIONS_DIALOG_DELAY = 3000;
+  private static final int GRANT_BUTTON_INDEX = 1;
+
+  public static void allowPermissionsIfNeeded(String permissionNeeded) {
+    try {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && !hasNeededPermission(InstrumentationRegistry.getTargetContext(),
+          permissionNeeded)) {
+        sleep(PERMISSIONS_DIALOG_DELAY);
+        UiDevice device = UiDevice.getInstance(getInstrumentation());
+        UiObject allowPermissions = device.findObject(new UiSelector()
+            .clickable(true)
+            .checkable(false)
+            .index(GRANT_BUTTON_INDEX));
+        if (allowPermissions.exists()) {
+          allowPermissions.click();
+        }
+      }
+    } catch (UiObjectNotFoundException e) {
+      System.out.println("There is no permissions dialog to interact with");
+    }
+  }
+
+  private static boolean hasNeededPermission(Context context, String permissionNeeded) {
+    int permissionStatus = ContextCompat.checkSelfPermission(context, permissionNeeded);
+    return permissionStatus == PackageManager.PERMISSION_GRANTED;
+  }
+
+  private static void sleep(long millis) {
+    try {
+      Thread.sleep(millis);
+    } catch (InterruptedException e) {
+      throw new RuntimeException("Cannot execute Thread.sleep()");
+    }
+  }
+}

--- a/library/src/main/java/com/schibsted/spain/barista/permission/PermissionGranter.java
+++ b/library/src/main/java/com/schibsted/spain/barista/permission/PermissionGranter.java
@@ -34,7 +34,7 @@ public class PermissionGranter {
         }
       }
     } catch (UiObjectNotFoundException e) {
-      Log.e("Barista", "There is no permissions dialog to interact with");
+      Log.e("Barista", "There is no permissions dialog to interact with", e);
     }
   }
 

--- a/library/src/main/java/com/schibsted/spain/barista/permission/PermissionGranter.java
+++ b/library/src/main/java/com/schibsted/spain/barista/permission/PermissionGranter.java
@@ -9,6 +9,7 @@ import android.support.test.uiautomator.UiDevice;
 import android.support.test.uiautomator.UiObject;
 import android.support.test.uiautomator.UiObjectNotFoundException;
 import android.support.test.uiautomator.UiSelector;
+import android.util.Log;
 
 import static android.support.test.InstrumentationRegistry.getInstrumentation;
 import static com.schibsted.spain.barista.BaristaSleepActions.sleep;
@@ -33,7 +34,7 @@ public class PermissionGranter {
         }
       }
     } catch (UiObjectNotFoundException e) {
-      System.out.println("There is no permissions dialog to interact with");
+      Log.e("Barista", "setup");
     }
   }
 


### PR DESCRIPTION
As Barista is the last and better way to solve instrumental tests issues, we want to solve the issue related with allowing permissions with the system dialog. As Espresso can't tap that Dialog 'cause it's not an app one but a system one, we need to add UiAutomator.