### PR TITLE
Clear preferences test rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,14 @@ The new Marshmallow permissions system requires checking for permissions at runt
 PermissionGranter.allowPermissionsIfNeeded(Manifest.permission.GET_ACCOUNTS);
 ```
 
+## Resetting the app before running each test
+
+As tests should be isolated, they need to set the environment before running. As Espresso doesn't help achieving it, Barista offers a set of rules to clear the app before running tests.
+
+```java
+@Rule public ClearPreferencesRule clearPreferencesRule = new ClearPreferencesRule();
+```
+
 # Download
 
 ```gradle

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ PermissionGranter.allowPermissionsIfNeeded(Manifest.permission.GET_ACCOUNTS);
 
 ## Resetting the app before running each test
 
-As tests should be isolated, they need to set the environment before running. As Espresso doesn't help achieving it, Barista offers a set of rules to clear the app before running tests.
+As tests should be isolated, they need to set the environment before running. As Espresso doesn't help achieving it, Barista offers a set of rules to clear the app's data before running each test.
 
 ```java
 @Rule public ClearPreferencesRule clearPreferencesRule = new ClearPreferencesRule();

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The new Marshmallow permissions system requires checking for permissions at runt
 PermissionGranter.allowPermissionsIfNeeded(Manifest.permission.GET_ACCOUNTS);
 ```
 
-## Resetting the app before running each test
+## Resetting the app's data before running each test
 
 As tests should be isolated, they need to set the environment before running. As Espresso doesn't help achieving it, Barista offers a set of rules to clear the app's data before running each test.
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ PermissionGranter.allowPermissionsIfNeeded(Manifest.permission.GET_ACCOUNTS);
 As tests should be isolated, they need to set the environment before running. As Espresso doesn't help achieving it, Barista offers a set of rules to clear the app's data before running each test.
 
 ```java
-@Rule public ClearPreferencesRule clearPreferencesRule = new ClearPreferencesRule();
+@Rule public ClearPreferencesRule clearPreferencesRule = new ClearPreferencesRule(); // Clear all app's SharedPreferences
 ```
 
 # Download

--- a/library/src/main/java/com/schibsted/spain/barista/cleardata/ClearPreferencesRule.java
+++ b/library/src/main/java/com/schibsted/spain/barista/cleardata/ClearPreferencesRule.java
@@ -1,0 +1,57 @@
+package com.schibsted.spain.barista.cleardata;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.support.annotation.NonNull;
+import android.support.test.InstrumentationRegistry;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+public class ClearPreferencesRule implements TestRule {
+
+  @Override
+  public Statement apply(final Statement base, Description description) {
+    return new Statement() {
+      @Override
+      public void evaluate() throws Throwable {
+        clearData();
+        base.evaluate();
+        clearData();
+      }
+    };
+  }
+
+  private void clearData() {
+    List<SharedPreferences> allPrefs = getAllPreferencesFiles();
+    for (SharedPreferences prefs : allPrefs) {
+      prefs.edit().clear().apply();
+    }
+  }
+
+  @NonNull
+  private List<SharedPreferences> getAllPreferencesFiles() {
+    Context context = InstrumentationRegistry.getTargetContext().getApplicationContext();
+    String rootPath = context.getApplicationInfo().dataDir + "/shared_prefs";
+    File prefsFolder = new File(rootPath);
+
+    String[] children = prefsFolder.list();
+    if (children == null) {
+      return Collections.emptyList();
+    }
+
+    List<SharedPreferences> allPrefs = new ArrayList<>();
+    for (String prefFileName : children) {
+      String prefName = prefFileName.endsWith(".xml")
+          ? prefFileName.substring(0, prefFileName.indexOf(".xml"))
+          : prefFileName;
+      SharedPreferences prefs = context.getSharedPreferences(prefName, 0);
+      allPrefs.add(prefs);
+    }
+    return allPrefs;
+  }
+}

--- a/library/src/main/java/com/schibsted/spain/barista/cleardata/ClearPreferencesRule.java
+++ b/library/src/main/java/com/schibsted/spain/barista/cleardata/ClearPreferencesRule.java
@@ -13,7 +13,7 @@ import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
 /**
- * This rule clears all SharedPreferences before running each test
+ * This rule clears all app's SharedPreferences before running each test
  */
 public class ClearPreferencesRule implements TestRule {
 

--- a/library/src/main/java/com/schibsted/spain/barista/cleardata/ClearPreferencesRule.java
+++ b/library/src/main/java/com/schibsted/spain/barista/cleardata/ClearPreferencesRule.java
@@ -12,6 +12,9 @@ import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
+/**
+ * This rule clears all SharedPreferences before running each test
+ */
 public class ClearPreferencesRule implements TestRule {
 
   @Override

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/ClearPreferencesRuleTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/ClearPreferencesRuleTest.java
@@ -1,0 +1,40 @@
+package com.schibsted.spain.barista.sample;
+
+import android.support.test.rule.ActivityTestRule;
+import com.schibsted.spain.barista.BaristaClickActions;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static com.schibsted.spain.barista.BaristaAssertions.assertDisplayed;
+
+public class ClearPreferencesRuleTest {
+
+  @Rule
+  public ActivityTestRule<PreferencesActivity> activityRule = new ActivityTestRule<>(PreferencesActivity.class, true, false);
+
+  @Test
+  public void checkOnceThatValueIsZeroFistAndOneAfterIncrement() throws Exception {
+    activityRule.launchActivity(null);
+
+    assertCurrentValueIs("0");
+    incrementValue();
+    assertCurrentValueIs("1");
+  }
+
+  @Test
+  public void checkTwiceThatValueIsZeroFistAndOneAfterIncrement() throws Exception {
+    activityRule.launchActivity(null);
+
+    assertCurrentValueIs("0");
+    incrementValue();
+    assertCurrentValueIs("1");
+  }
+
+  private void assertCurrentValueIs(String expectedValue) {
+    assertDisplayed(expectedValue);
+  }
+
+  private void incrementValue() {
+    BaristaClickActions.click(R.id.preference_increment_button);
+  }
+}

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/ClearPreferencesRuleTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/ClearPreferencesRuleTest.java
@@ -2,6 +2,7 @@ package com.schibsted.spain.barista.sample;
 
 import android.support.test.rule.ActivityTestRule;
 import com.schibsted.spain.barista.BaristaClickActions;
+import com.schibsted.spain.barista.cleardata.ClearPreferencesRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -11,6 +12,14 @@ public class ClearPreferencesRuleTest {
 
   @Rule
   public ActivityTestRule<PreferencesActivity> activityRule = new ActivityTestRule<>(PreferencesActivity.class, true, false);
+
+  @Rule
+  public ClearPreferencesRule clearPreferencesRule = new ClearPreferencesRule();
+
+  //
+  // Only one of these two tests will succeed when preferences are not cleared.
+  // They rely on preferences being cleared between test executions.
+  //
 
   @Test
   public void checkOnceThatValueIsZeroFistAndOneAfterIncrement() throws Exception {

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -26,6 +26,7 @@
     <activity android:name=".LabelActivity"/>
     <activity android:name=".ViewPagerActivity"/>
     <activity android:name=".DialogActivity"/>
+    <activity android:name=".PreferencesActivity"/>
     <activity android:name=".NavigationDrawerActivity"
         android:theme="@style/AppTheme.NoActionBar">
       <intent-filter>

--- a/sample/src/main/java/com/schibsted/spain/barista/sample/PreferencesActivity.java
+++ b/sample/src/main/java/com/schibsted/spain/barista/sample/PreferencesActivity.java
@@ -1,0 +1,49 @@
+package com.schibsted.spain.barista.sample;
+
+import android.app.Activity;
+import android.content.SharedPreferences;
+import android.os.Bundle;
+import android.preference.PreferenceManager;
+import android.view.View;
+import android.widget.TextView;
+
+public class PreferencesActivity extends Activity {
+
+  private static final String PREFERENCE_KEY = "value";
+  private static final int PREFERENCE_DEFAULT_VALUE = 0;
+
+  private SharedPreferences preferences;
+  private TextView currentValueText;
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_preferences);
+
+    preferences = PreferenceManager.getDefaultSharedPreferences(this);
+
+    currentValueText = ((TextView) findViewById(R.id.preference_current_value));
+    findViewById(R.id.preference_increment_button).setOnClickListener(new View.OnClickListener() {
+      @Override
+      public void onClick(View v) {
+        incrementValue();
+        showCurrentValue();
+      }
+    });
+
+    showCurrentValue();
+  }
+
+  private void showCurrentValue() {
+    int currentValue = preferences.getInt(PREFERENCE_KEY, PREFERENCE_DEFAULT_VALUE);
+    currentValueText.setText(String.valueOf(currentValue));
+  }
+
+  private void incrementValue() {
+    int currentValue = preferences.getInt(PREFERENCE_KEY, PREFERENCE_DEFAULT_VALUE);
+    int newValue = currentValue + 1;
+    preferences.edit()
+        .putInt(PREFERENCE_KEY, newValue)
+        .apply();
+  }
+}

--- a/sample/src/main/res/layout/activity_preferences.xml
+++ b/sample/src/main/res/layout/activity_preferences.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              android:orientation="vertical"
+              android:layout_width="match_parent"
+              android:layout_height="match_parent"
+    >
+
+  <TextView
+      android:id="@+id/preference_current_value"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      />
+  <Button
+      android:id="@+id/preference_increment_button"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:text="Increment value"
+      />
+</LinearLayout>


### PR DESCRIPTION
This rule lets us clear all preferences from the app between each test method. This way they are independent of any side-effects happening in any test.

TODO: 
- [x] Add Javadoc to the rule
- [x] Explain in the readme