### PR TITLE
Run upload task on PRs also

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_script:
   - adb shell settings put global animator_duration_scale 0 &
   - adb shell input keyevent 82 &
 script:
-  - ./gradlew check
+  - scripts/bintrayUpload.sh
 deploy:
   - provider: script
     script: scripts/bintrayUpload.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_script:
   - adb shell settings put global animator_duration_scale 0 &
   - adb shell input keyevent 82 &
 script:
-  - scripts/bintrayUpload.sh
+  - scripts/build.sh
 deploy:
   - provider: script
     script: scripts/bintrayUpload.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_script:
   - adb shell settings put global animator_duration_scale 0 &
   - adb shell input keyevent 82 &
 script:
-  - scripts/build.sh
+  - ./gradlew build bintrayUpload -PbintrayUser=dryrun-user -PbintrayKey=dryrun-key -PdryRun=true
 deploy:
   - provider: script
     script: scripts/bintrayUpload.sh

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-./gradlew build bintrayUpload -PbintrayUser=dryrun-user -PbintrayKey=dryrun-key -PdryRun=true

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+./gradlew build bintrayUpload -PbintrayUser=dryrun-user -PbintrayKey=dryrun-key -PdryRun=true


### PR DESCRIPTION
Using dry run and fake auth, of course.

This solves the problems found at #34, where some tasks are only run when releasing and might fail after a new PR has been merged already.

The original idea was to run the task that failed in my case (`: library:mavenAndroidJavadocs`), but I think using the dryRun feature of the publishing plugin is better. This way we make sure all release tasks are executed except for the upload itself.