### PR TITLE
Fixes click on RecyclerView when ItemView is wrapped

### DIFF
--- a/library/src/main/java/com/schibsted/spain/barista/custom/PerformClickAction.java
+++ b/library/src/main/java/com/schibsted/spain/barista/custom/PerformClickAction.java
@@ -6,6 +6,7 @@ import android.view.View;
 
 import org.hamcrest.Matcher;
 
+import static android.support.test.espresso.action.ViewActions.click;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
 
 public class PerformClickAction {
@@ -32,7 +33,11 @@ public class PerformClickAction {
 
       @Override
       public void perform(UiController uiController, View view) {
-        view.performClick();
+        if (view.isClickable()) {
+          view.performClick();
+        } else {
+          click().perform(uiController, view);
+        }
       }
     };
   }

--- a/library/src/main/java/com/schibsted/spain/barista/custom/PerformClickAction.java
+++ b/library/src/main/java/com/schibsted/spain/barista/custom/PerformClickAction.java
@@ -36,8 +36,12 @@ public class PerformClickAction {
         if (view.isClickable()) {
           view.performClick();
         } else {
-          click().perform(uiController, view);
+          propagateClickToChildren(uiController, view);
         }
+      }
+
+      private void propagateClickToChildren(UiController uiController, View view) {
+        click().perform(uiController, view);
       }
     };
   }

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/RecyclerViewTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/RecyclerViewTest.java
@@ -21,32 +21,32 @@ public class RecyclerViewTest {
   @Test
   public void checkClickRecyclerViewItem_byPosition_atTwo() {
     clickRecyclerViewItem(R.id.recycler, 2);
-    assertDisplayed("Avocado");
+    assertDisplayed("Avocado has been clicked");
   }
 
   //region Clicks
   @Test
   public void checkClickRecyclerViewItem_byPosition_atThree() {
     clickRecyclerViewItem(R.id.recycler, 3);
-    assertDisplayed("Banana");
+    assertDisplayed("Banana has been clicked");
   }
 
   @Test
   public void checkClickRecyclerViewItem_byPosition_atTwenty() {
     clickRecyclerViewItem(R.id.recycler, 20);
-    assertDisplayed("Durian");
+    assertDisplayed("Durian has been clicked");
   }
 
   @Test
   public void checkClickRecyclerViewItem_byPosition_atFourty() {
     clickRecyclerViewItem(R.id.recycler, 40);
-    assertDisplayed("Lime");
+    assertDisplayed("Lime has been clicked");
   }
 
   @Test
   public void checkClickRecyclerViewItem_byPosition_atSixty() {
     clickRecyclerViewItem(R.id.recycler, 60);
-    assertDisplayed("Papaya");
+    assertDisplayed("Papaya has been clicked");
   }
   //endregion
 

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/WrappedViewClickTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/WrappedViewClickTest.java
@@ -17,28 +17,28 @@ public class WrappedViewClickTest {
       new ActivityTestRule<>(WrappedViewActivity.class);
 
   @Test
-  public void click_on_button() throws Exception {
+  public void clickOnButton() throws Exception {
     onView(withId(R.id.button)).perform(click());
 
     assertDisplayed("Clicked");
   }
 
   @Test
-  public void click_on_button_with_custom_action() throws Exception {
+  public void clickOnButtonWithCustomAction() throws Exception {
     onView(withId(R.id.button)).perform(clickUsingPerformClick());
 
     assertDisplayed("Clicked");
   }
 
   @Test
-  public void click_on_button_wrapper() throws Exception {
+  public void clickOnButtonWrapper() throws Exception {
     onView(withId(R.id.button_wrapper)).perform(click());
 
     assertDisplayed("Clicked");
   }
 
   @Test
-  public void click_on_button_wrapper_with_custom_action() throws Exception {
+  public void clickOnButtonWrapperWithCustomAction() throws Exception {
     onView(withId(R.id.button_wrapper)).perform(clickUsingPerformClick());
 
     assertDisplayed("Clicked");

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/WrappedViewClickTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/WrappedViewClickTest.java
@@ -1,0 +1,46 @@
+package com.schibsted.spain.barista.sample;
+
+import android.support.test.rule.ActivityTestRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static com.schibsted.spain.barista.BaristaAssertions.assertDisplayed;
+import static com.schibsted.spain.barista.custom.PerformClickAction.clickUsingPerformClick;
+
+public class WrappedViewClickTest {
+
+  @Rule
+  public ActivityTestRule<WrappedViewActivity> activityTestRule =
+      new ActivityTestRule<>(WrappedViewActivity.class);
+
+  @Test
+  public void click_on_button() throws Exception {
+    onView(withId(R.id.button)).perform(click());
+
+    assertDisplayed("Clicked");
+  }
+
+  @Test
+  public void click_on_button_with_custom_action() throws Exception {
+    onView(withId(R.id.button)).perform(clickUsingPerformClick());
+
+    assertDisplayed("Clicked");
+  }
+
+  @Test
+  public void click_on_button_wrapper() throws Exception {
+    onView(withId(R.id.button_wrapper)).perform(click());
+
+    assertDisplayed("Clicked");
+  }
+
+  @Test
+  public void click_on_button_wrapper_with_custom_action() throws Exception {
+    onView(withId(R.id.button_wrapper)).perform(clickUsingPerformClick());
+
+    assertDisplayed("Clicked");
+  }
+}

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -29,6 +29,7 @@
     <activity android:name=".PreferencesActivity"/>
     <activity android:name=".DatabaseActivity"/>
     <activity android:name=".HelloWorldActivity"/>
+    <activity android:name=".WrappedViewActivity" />
     <activity android:name=".NavigationDrawerActivity"
         android:theme="@style/AppTheme.NoActionBar">
       <intent-filter>

--- a/sample/src/main/java/com/schibsted/spain/barista/sample/RecyclerViewActivity.java
+++ b/sample/src/main/java/com/schibsted/spain/barista/sample/RecyclerViewActivity.java
@@ -59,13 +59,13 @@ public class RecyclerViewActivity extends AppCompatActivity {
       return new ViewHolder(root, textView, yesButton, noButton);
     }
 
-    public void onBindViewHolder(ViewHolder holder, int position) {
+    public void onBindViewHolder(final ViewHolder holder, int position) {
       holder.textView.setText(items[position]);
-      holder.textView.setOnClickListener(new View.OnClickListener() {
+      holder.itemView.setOnClickListener(new View.OnClickListener() {
         @Override
         public void onClick(View view) {
           Intent i = new Intent(activity, LabelActivity.class);
-          i.putExtra(LabelActivity.EXTRA_TEXT, ((TextView) view).getText().toString() + " has been clicked");
+          i.putExtra(LabelActivity.EXTRA_TEXT, holder.textView.getText().toString() + " has been clicked");
           activity.startActivity(i);
         }
       });

--- a/sample/src/main/java/com/schibsted/spain/barista/sample/RecyclerViewActivity.java
+++ b/sample/src/main/java/com/schibsted/spain/barista/sample/RecyclerViewActivity.java
@@ -65,7 +65,7 @@ public class RecyclerViewActivity extends AppCompatActivity {
         @Override
         public void onClick(View view) {
           Intent i = new Intent(activity, LabelActivity.class);
-          i.putExtra(LabelActivity.EXTRA_TEXT, ((TextView) view).getText().toString());
+          i.putExtra(LabelActivity.EXTRA_TEXT, ((TextView) view).getText().toString() + " has been clicked");
           activity.startActivity(i);
         }
       });

--- a/sample/src/main/java/com/schibsted/spain/barista/sample/WrappedViewActivity.java
+++ b/sample/src/main/java/com/schibsted/spain/barista/sample/WrappedViewActivity.java
@@ -1,0 +1,21 @@
+package com.schibsted.spain.barista.sample;
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.view.View;
+
+public class WrappedViewActivity extends Activity {
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_wrapped_view);
+
+    findViewById(R.id.button).setOnClickListener(new View.OnClickListener() {
+      @Override
+      public void onClick(View v) {
+        findViewById(R.id.text).setVisibility(View.VISIBLE);
+      }
+    });
+  }
+}

--- a/sample/src/main/res/layout/activity_wrapped_view.xml
+++ b/sample/src/main/res/layout/activity_wrapped_view.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+             xmlns:tools="http://schemas.android.com/tools"
+             android:layout_width="match_parent"
+             android:layout_height="match_parent"
+    >
+
+
+  <FrameLayout
+      android:id="@+id/button_wrapper"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_gravity="center"
+      >
+    <Button
+        android:id="@+id/button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Wrapped button"
+        />
+  </FrameLayout>
+
+  <TextView
+      android:id="@+id/text"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:text="Clicked"
+      android:visibility="gone"
+      tools:visibility="visible"
+      />
+
+
+</FrameLayout>


### PR DESCRIPTION
This PR fixes the issue in #47.

On PR #40 we introduced a change to avoid clicking wrong things in a RecyclerView row, and allow clicking child views inside a row.

Unfortunately, that last change also broke the click when the ClickListener is set in a child view and not directly in the ItemView, as described in #47.

In this PR we:
- Reproduce the issue with a broken test (`WrappedViewClickTest`).
- Fix some flaky tests on RecyclerViewTest that were already giving false positives.
- Fix the original issue by **only** using `performClick()` when the view is clickable, or else use Espresso's `click()` action to allow propagating the click as usual.