### PR TITLE
Update gradle and Build Tools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,15 +17,6 @@ android:
   - android-25
   - extra
   - addon
-  - sys-img-armeabi-v7a-android-19
-before_script:
-  - echo no | android create avd --force -n test -t android-19 --abi armeabi-v7a -s WXGA800
-  - emulator -avd test -no-skin -no-audio -no-window &
-  - android-wait-for-emulator
-  - adb shell settings put global window_animation_scale 0 &
-  - adb shell settings put global transition_animation_scale 0 &
-  - adb shell settings put global animator_duration_scale 0 &
-  - adb shell input keyevent 82 &
 script:
   - ./gradlew build bintrayUpload -PbintrayUser=dryrun-user -PbintrayKey=dryrun-key -PdryRun=true
 deploy:

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.3'
+        classpath 'com.android.tools.build:gradle:2.3.2'
         classpath 'com.novoda:bintray-release:0.3.4'
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Dec 28 10:00:20 PST 2015
+#Tue May 16 16:31:24 CEST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -29,9 +29,12 @@ dependencies {
     compile('com.android.support.test.espresso:espresso-contrib:2.0') {
         exclude module: 'support-v4'
     }
+
     compile 'com.android.support.test.uiautomator:uiautomator-v18:2.1.2'
+
     compile 'com.android.support:support-annotations:25.1.0'
     compile 'com.android.support:support-core-ui:25.1.0'
+    compile 'com.android.support:recyclerview-v7:25.1.0'
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.assertj:assertj-core:1.7.0'


### PR DESCRIPTION
Android Studio warned me about living in the past. This PR fixes it.

In addition, as one build crashed while waiting for an emulator (that we don't use yet), this PR also avoids waiting for it.