### PR TITLE
RecyclerView and SwipeRefreshLayout actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ swipeViewPagerBack(R.id.pager);
 openDrawer(R.id.drawer);
 closeDrawer(R.id.drawer);
 
+//Interact with SwipeRefreshLayout (pullToRefresh)
+refresh(R.id.swiperefresh);
+
 // And another tricky feature
 sleep(2000);
 sleep(2, SECONDS);
@@ -112,6 +115,9 @@ assertDrawerIsClosed(R.id.drawer);
 // Check EditText's hints
 assertHint(R.id.edittext, R.string.hint);
 assertHint(R.id.edittext, "Hint");
+
+//Check recyclerView item count against expected item count
+assertRecyclerViewItemCount(R.id.recycler, 10);
 
 // And another tricky feature
 assertThatBackButtonClosesTheApp();

--- a/library/src/main/java/com/schibsted/spain/barista/BaristaAssertions.java
+++ b/library/src/main/java/com/schibsted/spain/barista/BaristaAssertions.java
@@ -5,6 +5,7 @@ import android.support.annotation.StringRes;
 import android.support.test.espresso.NoActivityResumedException;
 import android.util.Log;
 import com.schibsted.spain.barista.androidresource.ResourceTypeChecker;
+import com.schibsted.spain.barista.custom.RecyclerViewItemCountAssertion;
 import com.schibsted.spain.barista.exception.BaristaArgumentTypeException;
 
 import static android.support.test.espresso.Espresso.onView;
@@ -20,6 +21,7 @@ import static android.support.test.espresso.matcher.ViewMatchers.isNotChecked;
 import static android.support.test.espresso.matcher.ViewMatchers.withHint;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static com.schibsted.spain.barista.custom.DisplayedMatchers.displayedWithId;
 import static com.schibsted.spain.barista.custom.HelperMatchers.firstViewOf;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.core.IsNot.not;
@@ -135,6 +137,11 @@ public class BaristaAssertions {
       Log.d("Barista",
           "As the Activity is the first one of the stack, we expected this error. Yes, the back button closes the app!");
     }
+  }
+
+  public static void assertRecyclerViewItemCount(@IdRes int recyclerViewId, int expectedItemCount) {
+    onView(displayedWithId(recyclerViewId)).check(
+        new RecyclerViewItemCountAssertion(expectedItemCount));
   }
 
   public static void assertDrawerIsOpen(@IdRes int id) {

--- a/library/src/main/java/com/schibsted/spain/barista/BaristaRecyclerViewActions.java
+++ b/library/src/main/java/com/schibsted/spain/barista/BaristaRecyclerViewActions.java
@@ -3,6 +3,7 @@ package com.schibsted.spain.barista;
 import android.support.annotation.IdRes;
 import android.support.test.espresso.contrib.RecyclerViewActions;
 
+import com.schibsted.spain.barista.custom.RecyclerViewItemCountAssertion;
 import com.schibsted.spain.barista.exception.BaristaException;
 
 import static android.support.test.espresso.Espresso.onView;
@@ -42,5 +43,10 @@ public class BaristaRecyclerViewActions {
                                                 String text) {
     onView(displayedWithId(recyclerViewId)).perform(
         RecyclerViewActions.actionOnItemAtPosition(position, clickChildWithText(text)));
+  }
+
+  public static void checkRecyclerViewItemCount(@IdRes int recyclerViewId, int expectedItemCount) {
+    onView(displayedWithId(recyclerViewId)).check(
+        new RecyclerViewItemCountAssertion(expectedItemCount));
   }
 }

--- a/library/src/main/java/com/schibsted/spain/barista/BaristaRecyclerViewActions.java
+++ b/library/src/main/java/com/schibsted/spain/barista/BaristaRecyclerViewActions.java
@@ -2,8 +2,6 @@ package com.schibsted.spain.barista;
 
 import android.support.annotation.IdRes;
 import android.support.test.espresso.contrib.RecyclerViewActions;
-
-import com.schibsted.spain.barista.custom.RecyclerViewItemCountAssertion;
 import com.schibsted.spain.barista.exception.BaristaException;
 
 import static android.support.test.espresso.Espresso.onView;
@@ -43,10 +41,5 @@ public class BaristaRecyclerViewActions {
                                                 String text) {
     onView(displayedWithId(recyclerViewId)).perform(
         RecyclerViewActions.actionOnItemAtPosition(position, clickChildWithText(text)));
-  }
-
-  public static void checkRecyclerViewItemCount(@IdRes int recyclerViewId, int expectedItemCount) {
-    onView(displayedWithId(recyclerViewId)).check(
-        new RecyclerViewItemCountAssertion(expectedItemCount));
   }
 }

--- a/library/src/main/java/com/schibsted/spain/barista/BaristaSwipeRefreshActions.java
+++ b/library/src/main/java/com/schibsted/spain/barista/BaristaSwipeRefreshActions.java
@@ -1,17 +1,14 @@
 package com.schibsted.spain.barista;
 
 import android.support.annotation.IdRes;
-import com.schibsted.spain.barista.custom.CustomConstraintViewAction;
 
 import static android.support.test.espresso.Espresso.onView;
-import static android.support.test.espresso.action.ViewActions.swipeDown;
-import static android.support.test.espresso.matcher.ViewMatchers.isDisplayingAtLeast;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static com.schibsted.spain.barista.custom.SwipeRefreshActions.pullToRefresh;
 
 public class BaristaSwipeRefreshActions {
 
-  public static void pullToRefresh(@IdRes int swipeRefreshId) {
-    onView(withId(swipeRefreshId)).perform(
-        new CustomConstraintViewAction(swipeDown(), isDisplayingAtLeast(80)));
+  public static void refresh(@IdRes int swipeRefreshId) {
+    onView(withId(swipeRefreshId)).perform(pullToRefresh());
   }
 }

--- a/library/src/main/java/com/schibsted/spain/barista/BaristaSwipeRefreshActions.java
+++ b/library/src/main/java/com/schibsted/spain/barista/BaristaSwipeRefreshActions.java
@@ -1,0 +1,17 @@
+package com.schibsted.spain.barista;
+
+import android.support.annotation.IdRes;
+import com.schibsted.spain.barista.custom.CustomConstraintViewAction;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.swipeDown;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayingAtLeast;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+
+public class BaristaSwipeRefreshActions {
+
+  public static void pullToRefresh(@IdRes int swipeRefreshId) {
+    onView(withId(swipeRefreshId)).perform(
+        new CustomConstraintViewAction(swipeDown(), isDisplayingAtLeast(80)));
+  }
+}

--- a/library/src/main/java/com/schibsted/spain/barista/custom/CustomConstraintViewAction.java
+++ b/library/src/main/java/com/schibsted/spain/barista/custom/CustomConstraintViewAction.java
@@ -1,0 +1,32 @@
+package com.schibsted.spain.barista.custom;
+
+import android.support.test.espresso.UiController;
+import android.support.test.espresso.ViewAction;
+import android.view.View;
+import org.hamcrest.Matcher;
+
+public class CustomConstraintViewAction implements ViewAction {
+
+  private final ViewAction viewAction;
+  private final Matcher<View> constraint;
+
+  public CustomConstraintViewAction(ViewAction viewAction, Matcher<View> constraint) {
+    this.viewAction = viewAction;
+    this.constraint = constraint;
+  }
+
+  @Override
+  public Matcher<View> getConstraints() {
+    return constraint;
+  }
+
+  @Override
+  public String getDescription() {
+    return viewAction.getDescription();
+  }
+
+  @Override
+  public void perform(UiController uiController, View view) {
+    viewAction.perform(uiController, view);
+  }
+}

--- a/library/src/main/java/com/schibsted/spain/barista/custom/RecyclerViewItemCountAssertion.java
+++ b/library/src/main/java/com/schibsted/spain/barista/custom/RecyclerViewItemCountAssertion.java
@@ -1,0 +1,33 @@
+package com.schibsted.spain.barista.custom;
+
+import android.support.test.espresso.NoMatchingViewException;
+import android.support.test.espresso.ViewAssertion;
+import android.support.v7.widget.RecyclerView;
+import android.view.View;
+import org.hamcrest.Matcher;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class RecyclerViewItemCountAssertion implements ViewAssertion {
+  private final Matcher<Integer> matcher;
+
+  public RecyclerViewItemCountAssertion(Matcher<Integer> matcher) {
+    this.matcher = matcher;
+  }
+
+  public RecyclerViewItemCountAssertion(int count) {
+    this.matcher = is(count);
+  }
+
+  @Override
+  public void check(View view, NoMatchingViewException noViewFoundException) {
+    if (noViewFoundException != null) {
+      throw noViewFoundException;
+    }
+    RecyclerView recyclerView = (RecyclerView) view;
+    RecyclerView.Adapter adapter = recyclerView.getAdapter();
+    int recyclerViewItemCount = adapter.getItemCount();
+    assertThat(recyclerViewItemCount, matcher);
+  }
+}

--- a/library/src/main/java/com/schibsted/spain/barista/custom/RecyclerViewItemCountAssertion.java
+++ b/library/src/main/java/com/schibsted/spain/barista/custom/RecyclerViewItemCountAssertion.java
@@ -4,20 +4,15 @@ import android.support.test.espresso.NoMatchingViewException;
 import android.support.test.espresso.ViewAssertion;
 import android.support.v7.widget.RecyclerView;
 import android.view.View;
-import org.hamcrest.Matcher;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 public class RecyclerViewItemCountAssertion implements ViewAssertion {
-  private final Matcher<Integer> matcher;
+  private final int expectedCount;
 
-  public RecyclerViewItemCountAssertion(Matcher<Integer> matcher) {
-    this.matcher = matcher;
-  }
-
-  public RecyclerViewItemCountAssertion(int count) {
-    this.matcher = is(count);
+  public RecyclerViewItemCountAssertion(int expectedCount) {
+    this.expectedCount = expectedCount;
   }
 
   @Override
@@ -28,6 +23,6 @@ public class RecyclerViewItemCountAssertion implements ViewAssertion {
     RecyclerView recyclerView = (RecyclerView) view;
     RecyclerView.Adapter adapter = recyclerView.getAdapter();
     int recyclerViewItemCount = adapter.getItemCount();
-    assertThat(recyclerViewItemCount, matcher);
+    assertThat(recyclerViewItemCount, is(expectedCount));
   }
 }

--- a/library/src/main/java/com/schibsted/spain/barista/custom/SwipeRefreshActions.java
+++ b/library/src/main/java/com/schibsted/spain/barista/custom/SwipeRefreshActions.java
@@ -1,0 +1,37 @@
+package com.schibsted.spain.barista.custom;
+
+import android.support.test.espresso.UiController;
+import android.support.test.espresso.ViewAction;
+import android.support.v4.widget.SwipeRefreshLayout;
+import android.view.View;
+import org.hamcrest.Matcher;
+
+import static android.support.test.espresso.action.ViewActions.actionWithAssertions;
+import static android.support.test.espresso.action.ViewActions.swipeDown;
+import static android.support.test.espresso.matcher.ViewMatchers.isAssignableFrom;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayingAtLeast;
+import static org.hamcrest.Matchers.allOf;
+
+public class SwipeRefreshActions {
+
+    public static ViewAction pullToRefresh() {
+        return actionWithAssertions(new PullToRefresh());
+    }
+
+    public static class PullToRefresh implements ViewAction {
+        @Override
+        public Matcher<View> getConstraints() {
+            return allOf(isDisplayingAtLeast(80), isAssignableFrom(SwipeRefreshLayout.class));
+        }
+
+        @Override
+        public String getDescription() {
+            return "Perform pull-to-refresh action";
+        }
+
+        @Override
+        public void perform(UiController uiController, View view) {
+            swipeDown().perform(uiController, view);
+        }
+    }
+}

--- a/library/src/main/java/com/schibsted/spain/barista/custom/SwipeRefreshActions.java
+++ b/library/src/main/java/com/schibsted/spain/barista/custom/SwipeRefreshActions.java
@@ -14,24 +14,24 @@ import static org.hamcrest.Matchers.allOf;
 
 public class SwipeRefreshActions {
 
-    public static ViewAction pullToRefresh() {
-        return actionWithAssertions(new PullToRefresh());
+  public static ViewAction pullToRefresh() {
+    return actionWithAssertions(new PullToRefresh());
+  }
+
+  public static class PullToRefresh implements ViewAction {
+    @Override
+    public Matcher<View> getConstraints() {
+      return allOf(isDisplayingAtLeast(80), isAssignableFrom(SwipeRefreshLayout.class));
     }
 
-    public static class PullToRefresh implements ViewAction {
-        @Override
-        public Matcher<View> getConstraints() {
-            return allOf(isDisplayingAtLeast(80), isAssignableFrom(SwipeRefreshLayout.class));
-        }
-
-        @Override
-        public String getDescription() {
-            return "Perform pull-to-refresh action";
-        }
-
-        @Override
-        public void perform(UiController uiController, View view) {
-            swipeDown().perform(uiController, view);
-        }
+    @Override
+    public String getDescription() {
+      return "Perform pull-to-refresh action";
     }
+
+    @Override
+    public void perform(UiController uiController, View view) {
+      swipeDown().perform(uiController, view);
+    }
+  }
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -2,34 +2,35 @@ apply plugin: 'com.android.application'
 apply from: '../config/android-quality.gradle'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.1"
-    defaultConfig {
-        applicationId "com.schibsted.spain.barista.sample"
-        minSdkVersion 9
-        targetSdkVersion 25
-        versionCode 1
-        versionName "1.0"
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+  compileSdkVersion 25
+  buildToolsVersion "25.0.1"
+  defaultConfig {
+    applicationId "com.schibsted.spain.barista.sample"
+    minSdkVersion 9
+    targetSdkVersion 25
+    versionCode 1
+    versionName "1.0"
+    testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+  }
+  buildTypes {
+    release {
+      minifyEnabled false
+      proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
     }
-    buildTypes {
-        release {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-        }
-    }
+  }
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:recyclerview-v7:25.1.0'
-    compile "com.android.support:design:25.1.0"
+  compile fileTree(dir: 'libs', include: ['*.jar'])
 
-    testCompile 'junit:junit:4.12'
 
-    androidTestCompile project(':library')
-    androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2.2'
-    androidTestCompile 'com.android.support:recyclerview-v7:25.1.0'
+  androidTestCompile project(':library')
 
+  compile 'com.android.support:appcompat-v7:25.1.0'
+  compile 'com.android.support:recyclerview-v7:25.1.0'
+  compile 'com.android.support:design:25.1.0'
+  compile 'com.android.support.constraint:constraint-layout:1.0.2'
+  testCompile 'junit:junit:4.12'
+  androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2.2'
+  androidTestCompile 'com.android.support:recyclerview-v7:25.1.0'
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -22,15 +22,14 @@ android {
 
 dependencies {
   compile fileTree(dir: 'libs', include: ['*.jar'])
-
-
-  androidTestCompile project(':library')
-
   compile 'com.android.support:appcompat-v7:25.1.0'
   compile 'com.android.support:recyclerview-v7:25.1.0'
-  compile 'com.android.support:design:25.1.0'
-  compile 'com.android.support.constraint:constraint-layout:1.0.2'
+  compile "com.android.support:design:25.1.0"
+
   testCompile 'junit:junit:4.12'
+
+  androidTestCompile project(':library')
   androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2.2'
   androidTestCompile 'com.android.support:recyclerview-v7:25.1.0'
+
 }

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/RecyclerViewTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/RecyclerViewTest.java
@@ -2,12 +2,12 @@ package com.schibsted.spain.barista.sample;
 
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
-
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static com.schibsted.spain.barista.BaristaAssertions.assertDisplayed;
+import static com.schibsted.spain.barista.BaristaRecyclerViewActions.checkRecyclerViewItemCount;
 import static com.schibsted.spain.barista.BaristaRecyclerViewActions.clickRecyclerViewItem;
 import static com.schibsted.spain.barista.BaristaRecyclerViewActions.clickRecyclerViewItemChild;
 import static com.schibsted.spain.barista.BaristaRecyclerViewActions.scrollTo;
@@ -161,4 +161,12 @@ public class RecyclerViewTest {
     assertDisplayed("'no' has been clicked");
   }
   //endregion
+
+  //region Item count
+  @Test
+  public void checkRecyclerViewItemCount_byDataSetCount() {
+    int expectedCount = RecyclerViewActivity.DATA_COUNT;
+    checkRecyclerViewItemCount(R.id.recycler, expectedCount);
+  }
+  //endRegion
 }

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/RecyclerViewTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/RecyclerViewTest.java
@@ -7,7 +7,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static com.schibsted.spain.barista.BaristaAssertions.assertDisplayed;
-import static com.schibsted.spain.barista.BaristaRecyclerViewActions.checkRecyclerViewItemCount;
+import static com.schibsted.spain.barista.BaristaAssertions.assertRecyclerViewItemCount;
 import static com.schibsted.spain.barista.BaristaRecyclerViewActions.clickRecyclerViewItem;
 import static com.schibsted.spain.barista.BaristaRecyclerViewActions.clickRecyclerViewItemChild;
 import static com.schibsted.spain.barista.BaristaRecyclerViewActions.scrollTo;
@@ -164,9 +164,9 @@ public class RecyclerViewTest {
 
   //region Item count
   @Test
-  public void checkRecyclerViewItemCount_byDataSetCount() {
+  public void assertItemCount_byDataSetCount() {
     int expectedCount = RecyclerViewActivity.DATA_COUNT;
-    checkRecyclerViewItemCount(R.id.recycler, expectedCount);
+    assertRecyclerViewItemCount(R.id.recycler, expectedCount);
   }
   //endRegion
 }

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/SwipeRefreshTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/SwipeRefreshTest.java
@@ -1,0 +1,22 @@
+package com.schibsted.spain.barista.sample;
+
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static com.schibsted.spain.barista.BaristaAssertions.assertDisplayed;
+import static com.schibsted.spain.barista.BaristaSwipeRefreshActions.pullToRefresh;
+
+@RunWith(AndroidJUnit4.class) public class SwipeRefreshTest {
+
+  @Rule public ActivityTestRule<SwipeRefreshActivity> activityRule =
+      new ActivityTestRule<>(SwipeRefreshActivity.class);
+
+  @Test
+  public void testSwipeRefresh_isRefreshing() {
+    pullToRefresh(R.id.swiperefresh);
+    assertDisplayed("I am refreshing!");
+  }
+}

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/SwipeRefreshTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/SwipeRefreshTest.java
@@ -7,16 +7,17 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static com.schibsted.spain.barista.BaristaAssertions.assertDisplayed;
-import static com.schibsted.spain.barista.BaristaSwipeRefreshActions.pullToRefresh;
+import static com.schibsted.spain.barista.BaristaSwipeRefreshActions.refresh;
 
-@RunWith(AndroidJUnit4.class) public class SwipeRefreshTest {
+@RunWith(AndroidJUnit4.class)
+public class SwipeRefreshTest {
 
   @Rule public ActivityTestRule<SwipeRefreshActivity> activityRule =
       new ActivityTestRule<>(SwipeRefreshActivity.class);
 
   @Test
   public void checkSwipeRefresh_isRefreshing() {
-    pullToRefresh(R.id.swiperefresh);
+    refresh(R.id.swiperefresh);
     assertDisplayed("I am refreshing!");
   }
 }

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/SwipeRefreshTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/SwipeRefreshTest.java
@@ -15,7 +15,7 @@ import static com.schibsted.spain.barista.BaristaSwipeRefreshActions.pullToRefre
       new ActivityTestRule<>(SwipeRefreshActivity.class);
 
   @Test
-  public void testSwipeRefresh_isRefreshing() {
+  public void checkSwipeRefresh_isRefreshing() {
     pullToRefresh(R.id.swiperefresh);
     assertDisplayed("I am refreshing!");
   }

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/introduction/IntroducingBaristaActions.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/introduction/IntroducingBaristaActions.java
@@ -26,6 +26,7 @@ import static com.schibsted.spain.barista.BaristaRecyclerViewActions.clickRecycl
 import static com.schibsted.spain.barista.BaristaScrollActions.scrollTo;
 import static com.schibsted.spain.barista.BaristaSleepActions.sleep;
 import static com.schibsted.spain.barista.BaristaSpinnerActions.clickSpinnerItem;
+import static com.schibsted.spain.barista.BaristaSwipeRefreshActions.refresh;
 import static com.schibsted.spain.barista.BaristaViewPagerActions.swipeViewPagerBack;
 import static com.schibsted.spain.barista.BaristaViewPagerActions.swipeViewPagerForward;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -83,6 +84,9 @@ public class IntroducingBaristaActions {
     // Interact with the navigation drawer
     openDrawer(R.id.drawer);
     closeDrawer(R.id.drawer);
+
+    //Interact with SwipeRefreshLayout (pullToRefresh)
+    refresh(R.id.swiperefresh);
 
     // And another tricky feature
     sleep(2000);

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/introduction/IntroducingBaristaAssertions.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/introduction/IntroducingBaristaAssertions.java
@@ -15,6 +15,7 @@ import static com.schibsted.spain.barista.BaristaAssertions.assertEnabled;
 import static com.schibsted.spain.barista.BaristaAssertions.assertHint;
 import static com.schibsted.spain.barista.BaristaAssertions.assertNotDisplayed;
 import static com.schibsted.spain.barista.BaristaAssertions.assertNotExist;
+import static com.schibsted.spain.barista.BaristaAssertions.assertRecyclerViewItemCount;
 import static com.schibsted.spain.barista.BaristaAssertions.assertThatBackButtonClosesTheApp;
 import static com.schibsted.spain.barista.BaristaAssertions.assertUnchecked;
 
@@ -66,6 +67,9 @@ public class IntroducingBaristaAssertions {
     // Check EditText's hints
     assertHint(R.id.edittext, R.string.hint);
     assertHint(R.id.edittext, "Hint");
+
+    //Check recyclerView item count against expected item count
+    assertRecyclerViewItemCount(R.id.recycler, 10);
 
     // And another tricky feature
     assertThatBackButtonClosesTheApp();

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.schibsted.spain.barista.sample"
->
+          package="com.schibsted.spain.barista.sample"
+    >
 
   <application
       android:allowBackup="true"
@@ -9,9 +9,8 @@
       android:label="@string/app_name"
       android:supportsRtl="true"
       android:theme="@style/AppTheme"
-  >
+      >
     <activity android:name=".SomeViewsWithDifferentVisibilitesActivity">
-
     </activity>
     <activity android:name=".FlowFirstScreen"/>
     <activity android:name=".FlowSecondScreen"/>
@@ -30,8 +29,12 @@
     <activity android:name=".PreferencesActivity"/>
     <activity android:name=".DatabaseActivity"/>
     <activity android:name=".HelloWorldActivity"/>
-    <activity android:name=".WrappedViewActivity" />
-    <activity android:name=".NavigationDrawerActivity" android:theme="@style/AppTheme.NoActionBar"/>
+    <activity android:name=".WrappedViewActivity"/>
+    <activity android:name=".SwipeRefreshActivity"/>
+    <activity
+        android:name=".NavigationDrawerActivity"
+        android:theme="@style/AppTheme.NoActionBar"
+        />
     <activity android:name=".RecyclerViewsInsideViewPagerActivity">
       <intent-filter>
         <action android:name="android.intent.action.MAIN"/>

--- a/sample/src/main/java/com/schibsted/spain/barista/sample/RecyclerViewActivity.java
+++ b/sample/src/main/java/com/schibsted/spain/barista/sample/RecyclerViewActivity.java
@@ -29,6 +29,8 @@ public class RecyclerViewActivity extends AppCompatActivity {
       "Solanumquitoense", "Strawberry", "Tamarillo", "Tamarind", "Uglifruit", "Yuzu"
   };
 
+  public static final int DATA_COUNT = FRUITS.length;
+
   @Override
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);

--- a/sample/src/main/java/com/schibsted/spain/barista/sample/SwipeRefreshActivity.java
+++ b/sample/src/main/java/com/schibsted/spain/barista/sample/SwipeRefreshActivity.java
@@ -1,0 +1,25 @@
+package com.schibsted.spain.barista.sample;
+
+import android.os.Bundle;
+import android.support.v4.widget.SwipeRefreshLayout;
+import android.support.v7.app.AppCompatActivity;
+import android.view.View;
+import android.widget.TextView;
+
+public class SwipeRefreshActivity extends AppCompatActivity {
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_swipe_refresh);
+    final SwipeRefreshLayout swipeRefreshLayout = (SwipeRefreshLayout) findViewById(R.id.swiperefresh);
+    swipeRefreshLayout.setOnRefreshListener(new SwipeRefreshLayout.OnRefreshListener() {
+      @Override
+      public void onRefresh() {
+        TextView textView = (TextView) findViewById(R.id.textview);
+        textView.setVisibility(View.VISIBLE);
+        swipeRefreshLayout.setRefreshing(false);
+      }
+    });
+  }
+}

--- a/sample/src/main/res/layout/activity_swipe_refresh.xml
+++ b/sample/src/main/res/layout/activity_swipe_refresh.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+             android:layout_width="match_parent"
+             android:layout_height="match_parent"
+    >
+  <android.support.v4.widget.SwipeRefreshLayout
+
+      android:id="@+id/swiperefresh"
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      >
+
+    <android.support.v7.widget.RecyclerView
+        android:id="@+id/recycler"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        />
+
+  </android.support.v4.widget.SwipeRefreshLayout>
+
+  <TextView
+      android:id="@+id/textview"
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      android:gravity="center"
+      android:text="@string/refreshing"
+      android:visibility="gone"
+      />
+
+</FrameLayout>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -14,4 +14,5 @@
   <string name="checked_checkbox">Checked checkbox</string>
   <string name="unchecked_checkbox">Unchecked checkbox</string>
   <string name="click">Click</string>
+  <string name="refreshing">I am refreshing!</string>
 </resources>


### PR DESCRIPTION
### Added several actions that are really needed, but, unfortunately, missing.

Added new `RecyclerView` action, comparing actual `RecyclerView` item count against expected item count. This is very useful when testing RecyclerView dataset count changes or complete refreshing. E.g. helps testing when datalist should be completely refreshed but instead it duplicates items.

Added Pull-To-Refresh action for the `SwipeRefreshLayout`.

Added new `ViewAction` that supports custom constraints. This is helpful when writing tests for `SwipeToRefresh` that is slightly obscured, since espresso internally requires views to be visible at least 90%.

Added tests for new features above.