### PR TITLE
Try EditorConfig file to ease massive collaboration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+root = true
+
+[*]
+
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
... but it's not as configurable as we need. If we want to use it, we need to change our checkstyle to match what EditorConfig generates. It just doesn't have as format customizations as we need.

I thought that the settings that appear in the main project readme were just a bit of all the settings it can manage... but nope. It's all it can do. Here's the list of powerups:
```
indent_style: “tab” or “space”
indent_size: a whole number
tab_width: a whole number
end_of_line: “lf”, “cr”, or “crlf”
charset: “latin1”, “utf-8”, “utf-8-bom”, “utf-16be” or “utf-16le”
trim_trailing_whitespace: “true” or “false”
insert_final_newline: “true” or “false”
```

As there's not a way to set the "continue line" spacing, one of the issues that we have is that this code:
```
UiObject allowPermissions = device.findObject(new UiSelector()
    .clickable(true)
```
is converted to:
```
UiObject allowPermissions = device.findObject(new UiSelector()
  .clickable(true)
```
And that makes checkstyle fail :·(

@Sloy @CristianGM any feedback there?