### PR TITLE
Create BaristaRule to rule them all

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Espresso is a great tool to test our Android apps via instrumental tests. With t
 
 On the other hand, if you tried Espresso, you’ll agree that its API is not discoverable.
 
-Barista introduces a discoverable API for the Espresso features. So, you and all the Android team will write instrumental tests with no effort. 
+Barista introduces a discoverable API for the Espresso features. So, you and all the Android team will write instrumental tests with no effort.
 
 ### Barista’s Actions API
 ```java
@@ -168,6 +168,26 @@ public void some_important_test() throws Exception {
   // ...
 }
 ```
+
+## One rule to rule them all
+
+All previous rules can be added at the same time by just adding the BaristaRule.
+```java
+@Rule
+public BaristaRule<MyActivity> baristaRule = BaristaRule.create(MyActivity.class);
+
+//...
+
+baristaRule.launchActivity();
+```
+
+The rule assumes some sane defaults:
+- Retry flaky tests: 10 attempts
+- Launch activity automatically: false
+- Initial touch mode enabled: true
+- Clear preferences
+- Clear databases
+
 
 ## Magic that Barista does for you
 

--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ The rule assumes some sane defaults:
 - Initial touch mode enabled: true
 - Clear preferences
 - Clear databases
+- Clear files
 
 
 ## Magic that Barista does for you

--- a/library/src/main/java/com/schibsted/spain/barista/BaristaRule.java
+++ b/library/src/main/java/com/schibsted/spain/barista/BaristaRule.java
@@ -24,7 +24,7 @@ public class BaristaRule<T extends Activity> implements TestRule {
   private final ClearDatabaseRule clearDatabaseRule;
   private final FlakyActivityTestRule<T> activityTestRule;
 
-  public BaristaRule(Class<T> activityClass) {
+  private BaristaRule(Class<T> activityClass) {
     this.clearDatabaseRule = new ClearDatabaseRule();
     this.clearPreferencesRule = new ClearPreferencesRule();
     this.activityTestRule = new FlakyActivityTestRule<>(activityClass,

--- a/library/src/main/java/com/schibsted/spain/barista/BaristaRule.java
+++ b/library/src/main/java/com/schibsted/spain/barista/BaristaRule.java
@@ -3,6 +3,7 @@ package com.schibsted.spain.barista;
 import android.app.Activity;
 import android.content.Intent;
 import com.schibsted.spain.barista.cleardata.ClearDatabaseRule;
+import com.schibsted.spain.barista.cleardata.ClearFilesRule;
 import com.schibsted.spain.barista.cleardata.ClearPreferencesRule;
 import com.schibsted.spain.barista.flakyespresso.FlakyActivityTestRule;
 import org.junit.rules.RuleChain;
@@ -22,11 +23,13 @@ public class BaristaRule<T extends Activity> implements TestRule {
 
   private final ClearPreferencesRule clearPreferencesRule;
   private final ClearDatabaseRule clearDatabaseRule;
+  private final ClearFilesRule clearFilesRule;
   private final FlakyActivityTestRule<T> activityTestRule;
 
   private BaristaRule(Class<T> activityClass) {
     this.clearDatabaseRule = new ClearDatabaseRule();
     this.clearPreferencesRule = new ClearPreferencesRule();
+    this.clearFilesRule = new ClearFilesRule();
     this.activityTestRule = new FlakyActivityTestRule<>(activityClass,
         INITIAL_TOUCH_MODE_ENABLED,
         LAUNCH_ACTIVITY_AUTOMATICALLY)
@@ -38,6 +41,7 @@ public class BaristaRule<T extends Activity> implements TestRule {
     return RuleChain.outerRule(activityTestRule)
         .around(clearPreferencesRule)
         .around(clearDatabaseRule)
+        .around(clearFilesRule)
         .apply(base, description);
   }
 

--- a/library/src/main/java/com/schibsted/spain/barista/BaristaRule.java
+++ b/library/src/main/java/com/schibsted/spain/barista/BaristaRule.java
@@ -1,0 +1,55 @@
+package com.schibsted.spain.barista;
+
+import android.app.Activity;
+import android.content.Intent;
+import com.schibsted.spain.barista.cleardata.ClearDatabaseRule;
+import com.schibsted.spain.barista.cleardata.ClearPreferencesRule;
+import com.schibsted.spain.barista.flakyespresso.FlakyActivityTestRule;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+public class BaristaRule<T extends Activity> implements TestRule {
+
+  private static final int DEFAULT_FLAKY_ATTEMPTS = 10;
+  private static final boolean LAUNCH_ACTIVITY_AUTOMATICALLY = false;
+  private static final boolean INITIAL_TOUCH_MODE_ENABLED = true;
+
+  public static <T extends Activity> BaristaRule<T> create(Class<T> activityClass) {
+    return new BaristaRule<>(activityClass);
+  }
+
+  private final ClearPreferencesRule clearPreferencesRule;
+  private final ClearDatabaseRule clearDatabaseRule;
+  private final FlakyActivityTestRule<T> activityTestRule;
+
+  public BaristaRule(Class<T> activityClass) {
+    this.clearDatabaseRule = new ClearDatabaseRule();
+    this.clearPreferencesRule = new ClearPreferencesRule();
+    this.activityTestRule = new FlakyActivityTestRule<>(activityClass,
+        INITIAL_TOUCH_MODE_ENABLED,
+        LAUNCH_ACTIVITY_AUTOMATICALLY)
+        .allowFlakyAttemptsByDefault(DEFAULT_FLAKY_ATTEMPTS);
+  }
+
+  @Override
+  public Statement apply(Statement base, Description description) {
+    return RuleChain.outerRule(activityTestRule)
+        .around(clearPreferencesRule)
+        .around(clearDatabaseRule)
+        .apply(base, description);
+  }
+
+  public void launchActivity() {
+    activityTestRule.launchActivity(null);
+  }
+
+  public void launchActivity(Intent startIntent) {
+    activityTestRule.launchActivity(startIntent);
+  }
+
+  public FlakyActivityTestRule<T> getActivityTestRule() {
+    return activityTestRule;
+  }
+}


### PR DESCRIPTION
This rule includes all other rules, so it's easier and simpler to write tests without boilerplate.

It assumes sane defaults, and doesn't really allow customisation. Whoever wants to do something different, they can use the individual rules instead. Defaults are:
- Flaky attempts (without annotation): 10
- Launch activity automatically: false
- Initial touch mode enabled: true
- Clear preferences: always
- Clear databases: always

I wasn't sure how to add tests for it... Repeating the same tests that all rules have it's a lot of duplication. And I don't know how to test that a rule includes other rules.

I just tested manually by changing the current rules tests and replacing the original rules with this one.
It works.

This solves #26

TODO:
- [x] Explain in README