### PR TITLE
Fix permission granter

### DIFF
--- a/library/src/main/java/com/schibsted/spain/barista/BaristaSleepActions.java
+++ b/library/src/main/java/com/schibsted/spain/barista/BaristaSleepActions.java
@@ -15,4 +15,16 @@ public class BaristaSleepActions {
   public static void sleep(long units, TimeUnit timeunit) {
     sleep(timeunit.toMillis(units));
   }
+
+  public static void sleepThread(long millis) {
+    try {
+      Thread.sleep(millis);
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static void sleepThread(long units, TimeUnit timeunit) {
+    sleepThread(timeunit.toMillis(units));
+  }
 }

--- a/library/src/main/java/com/schibsted/spain/barista/BaristaSleepActions.java
+++ b/library/src/main/java/com/schibsted/spain/barista/BaristaSleepActions.java
@@ -20,7 +20,7 @@ public class BaristaSleepActions {
     try {
       Thread.sleep(millis);
     } catch (InterruptedException e) {
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     }
   }
 

--- a/library/src/main/java/com/schibsted/spain/barista/permission/PermissionGranter.java
+++ b/library/src/main/java/com/schibsted/spain/barista/permission/PermissionGranter.java
@@ -13,7 +13,7 @@ import android.support.test.uiautomator.UiSelector;
 import android.util.Log;
 
 import static android.support.test.InstrumentationRegistry.getInstrumentation;
-import static com.schibsted.spain.barista.BaristaSleepActions.sleep;
+import static com.schibsted.spain.barista.BaristaSleepActions.sleepThread;
 
 @RequiresApi(18)
 public class PermissionGranter {
@@ -25,7 +25,7 @@ public class PermissionGranter {
     try {
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && !hasNeededPermission(InstrumentationRegistry.getTargetContext(),
           permissionNeeded)) {
-        sleep(PERMISSIONS_DIALOG_DELAY);
+        sleepThread(PERMISSIONS_DIALOG_DELAY);
         UiDevice device = UiDevice.getInstance(getInstrumentation());
         UiObject allowPermissions = device.findObject(new UiSelector()
             .clickable(true)

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/PermissionGranterTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/PermissionGranterTest.java
@@ -1,0 +1,57 @@
+package com.schibsted.spain.barista.sample;
+
+import android.Manifest;
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.os.Build;
+import android.support.annotation.RequiresApi;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.espresso.PerformException;
+import com.schibsted.spain.barista.BaristaRule;
+import com.schibsted.spain.barista.permission.PermissionGranter;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static com.schibsted.spain.barista.BaristaClickActions.click;
+
+public class PermissionGranterTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Rule
+  public BaristaRule<RuntimePermissionActivity> activityRule = BaristaRule.create(RuntimePermissionActivity.class);
+
+  @Before
+  public void setUp() throws Exception {
+    if (hasNeededPermission(InstrumentationRegistry.getTargetContext(), RuntimePermissionActivity.SOME_PERMISSION)) {
+      throw new IllegalStateException("This test expects you to not have the permission granted, remember to clear data");
+    }
+  }
+
+  @Test(expected = PerformException.class)
+  public void fails_when_using_permission() throws Exception {
+    activityRule.launchActivity();
+
+    click(R.id.use_permission_button);
+  }
+
+  @Test
+  @RequiresApi(api = Build.VERSION_CODES.JELLY_BEAN_MR2)
+  public void works_after_granting_permission() throws Exception {
+    activityRule.launchActivity();
+
+    click(R.id.request_permission_button);
+
+    PermissionGranter.allowPermissionsIfNeeded(Manifest.permission.READ_CONTACTS);
+
+    click(R.id.use_permission_button);
+  }
+
+  private static boolean hasNeededPermission(Context context, String permissionNeeded) {
+    int permissionStatus = context.checkPermission(permissionNeeded, android.os.Process.myPid(), android.os.Process.myUid());
+    return permissionStatus == PackageManager.PERMISSION_GRANTED;
+  }
+}

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -3,6 +3,8 @@
     package="com.schibsted.spain.barista.sample"
     >
 
+  <uses-permission android:name="android.permission.READ_CONTACTS"/>
+
   <application
       android:allowBackup="true"
       android:icon="@mipmap/ic_launcher"
@@ -48,6 +50,7 @@
         />
     <activity android:name=".RecyclerViewsInsideViewPagerActivity"/>
     <activity android:name=".NestedScrollViewActivity"/>
+    <activity android:name=".RuntimePermissionActivity" />
   </application>
 
 </manifest>

--- a/sample/src/main/java/com/schibsted/spain/barista/sample/RuntimePermissionActivity.java
+++ b/sample/src/main/java/com/schibsted/spain/barista/sample/RuntimePermissionActivity.java
@@ -1,0 +1,47 @@
+package com.schibsted.spain.barista.sample;
+
+import android.Manifest;
+import android.annotation.TargetApi;
+import android.content.pm.PackageManager;
+import android.os.Build;
+import android.os.Bundle;
+import android.support.v4.app.ActivityCompat;
+import android.support.v4.content.ContextCompat;
+import android.support.v7.app.AppCompatActivity;
+import android.view.View;
+
+@TargetApi(Build.VERSION_CODES.M)
+public class RuntimePermissionActivity extends AppCompatActivity {
+
+  public static final String SOME_PERMISSION = Manifest.permission.READ_CONTACTS;
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_runtime_permission);
+
+    findViewById(R.id.request_permission_button).setOnClickListener(new View.OnClickListener() {
+      @Override
+      public void onClick(View v) {
+        requestPermission();
+      }
+    });
+
+    findViewById(R.id.use_permission_button).setOnClickListener(new View.OnClickListener() {
+      @Override
+      public void onClick(View v) {
+        usePermission();
+      }
+    });
+  }
+
+  private void requestPermission() {
+    ActivityCompat.requestPermissions(this, new String[] { SOME_PERMISSION }, 1);
+  }
+
+  private void usePermission() {
+    if (ContextCompat.checkSelfPermission(this, SOME_PERMISSION) != PackageManager.PERMISSION_GRANTED) {
+      throw new IllegalStateException("Tried to use permission without having it");
+    }
+  }
+}

--- a/sample/src/main/res/layout/activity_runtime_permission.xml
+++ b/sample/src/main/res/layout/activity_runtime_permission.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    tools:context="com.schibsted.spain.barista.sample.RuntimePermissionActivity"
+    >
+
+  <Button
+      android:id="@+id/request_permission_button"
+      android:text="Request permission"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      />
+
+  <Button
+      android:id="@+id/use_permission_button"
+      android:text="Use permission"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      />
+
+
+</LinearLayout>


### PR DESCRIPTION
We were using a sleep() which uses a ViewAction to make a magic efficient sleep. But since the permission dialog is on top of the application, Espresso cannot run the ViewAction.

Soooo changing it to a Thread.sleep() that doesn't require any view makes it work.

This fixes #61 and probably #74