### PR TITLE
Remove api limit to PermissionGranter

### DIFF
--- a/library/src/main/java/com/schibsted/spain/barista/permission/PermissionGranter.java
+++ b/library/src/main/java/com/schibsted/spain/barista/permission/PermissionGranter.java
@@ -4,7 +4,6 @@ import android.content.Context;
 import android.content.pm.PackageManager;
 import android.os.Build;
 import android.support.annotation.NonNull;
-import android.support.annotation.RequiresApi;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.uiautomator.UiDevice;
 import android.support.test.uiautomator.UiObject;
@@ -15,7 +14,6 @@ import android.util.Log;
 import static android.support.test.InstrumentationRegistry.getInstrumentation;
 import static com.schibsted.spain.barista.BaristaSleepActions.sleepThread;
 
-@RequiresApi(18)
 public class PermissionGranter {
 
   private static final int PERMISSIONS_DIALOG_DELAY = 3000;


### PR DESCRIPTION
The PermissionGranter class is annotated with RequiresApi 18 (because UI automator requires that api level).
This means that using PermissionGranter in an application that supports APIs lower than 18, Lint will give an error.

But in sdks lower than 23 we don't even use UiAutomator because permissions are granted at install time, so we're actually fine.

This PR removes the annotation so that we don't mislead the user.
I've tried running the PermissionGranter test on an emulator with api 17 and it works just fine.