### PR TITLE
Remove @IdRes from click() actions

### DIFF
--- a/library/src/main/java/com/schibsted/spain/barista/BaristaClickActions.java
+++ b/library/src/main/java/com/schibsted/spain/barista/BaristaClickActions.java
@@ -1,6 +1,5 @@
 package com.schibsted.spain.barista;
 
-import android.support.annotation.IdRes;
 import android.support.test.espresso.AmbiguousViewMatcherException;
 import android.support.test.espresso.PerformException;
 import android.support.test.espresso.action.ViewActions;
@@ -19,7 +18,7 @@ public class BaristaClickActions {
 
   private static final ResourceTypeChecker RESOURCE_TYPE_CHECKER = new ResourceTypeChecker();
 
-  public static void click(@IdRes int id) {
+  public static void click(int id) {
     if (isIdResource(id)) {
       click(withId(id));
     } else if (isStringResource(id)) {


### PR DESCRIPTION
Since `BaristaClickActions.click()` supports both `R.id` and `R.string` we don't need anymore the `@IdRes` annotation