### PR TITLE
Improve the explanation when the PermissionsDialog tests fail

### DIFF
--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/PermissionGranterTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/PermissionGranterTest.java
@@ -30,7 +30,7 @@ public class PermissionGranterTest {
       throw new IllegalStateException("This test needs to run on a device with Android 23 or above");
     }
     if (hasNeededPermission(InstrumentationRegistry.getTargetContext(), RuntimePermissionActivity.SOME_PERMISSION)) {
-      throw new IllegalStateException("This test expects you to not have the permission granted, remember to clear data");
+      throw new IllegalStateException("This test expects you to not have the permission granted. Remember to clear data.");
     }
   }
 

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/PermissionGranterTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/PermissionGranterTest.java
@@ -26,9 +26,11 @@ public class PermissionGranterTest {
 
   @Before
   public void setUp() throws Exception {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+      throw new IllegalStateException("This test needs to run on a device with Android 23 or above");
+    }
     if (hasNeededPermission(InstrumentationRegistry.getTargetContext(), RuntimePermissionActivity.SOME_PERMISSION)) {
-      throw new IllegalStateException("This test expects you to not have the permission granted."
-          + "In addition, use an emulator with Android 23 or above, or this test will fail.");
+      throw new IllegalStateException("This test expects you to not have the permission granted, remember to clear data");
     }
   }
 

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/PermissionGranterTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/PermissionGranterTest.java
@@ -27,7 +27,8 @@ public class PermissionGranterTest {
   @Before
   public void setUp() throws Exception {
     if (hasNeededPermission(InstrumentationRegistry.getTargetContext(), RuntimePermissionActivity.SOME_PERMISSION)) {
-      throw new IllegalStateException("This test expects you to not have the permission granted, remember to clear data");
+      throw new IllegalStateException("This test expects you to not have the permission granted."
+          + "In addition, use an emulator with Android 23 or above, or this test will fail.");
     }
   }
 


### PR DESCRIPTION
In order to reproduce the issue #108, I ran the tests on my emulator. Two tests failed requesting me to clear the data. And I cleared the data. But the tests were failing.

Actually, they were failing because the emulator I was using was on Android 21, and it doesn't have the runtime permissions system.

With this PR, when running the tests on Android 22 or below, a message will explain that the tests fill wail on Android 22 or below. WOW! Rockets there 🚀 