### PR TITLE
Update to Espresso 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ android:
   - tools
   - tools
   - platform-tools
-  - build-tools-25.0.1
+  - build-tools-25.0.3
   - android-25
   - extra
   - addon

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,10 @@ android:
   - android-25
   - extra
   - addon
+
+  licenses:
+    - 'android-sdk-license-.+'
+
 script:
   - ./gradlew build bintrayUpload -PbintrayUser=dryrun-user -PbintrayKey=dryrun-key -PdryRun=true
 deploy:

--- a/README.md
+++ b/README.md
@@ -199,11 +199,21 @@ In order to speed up testing, Barista keeps in mind some considerations.
 
 # Download
 
+Include the Google Maven repository, required by Espresso 3:
+```gradle
+repositories {
+    maven { url "https://maven.google.com" }
+}
+```
+
+Finally just import Barista as a testing dependency:
 ```gradle
 androidTestCompile('com.schibsted.spain:barista:1.5.3') {
   exclude group: 'com.android.support'
 }
 ```
+
+Barista already includes `espresso-core` and `espresso-contrib`. If you need [any other Espresso package](https://developer.android.com/topic/libraries/testing-support-library/packages.html#atsl-dependencies) you can add them yourself.
 
 # License
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,3 @@
-// Top-level build file where you can add configuration options common to all sub-projects/modules.
-
 buildscript {
     repositories {
         jcenter()
@@ -13,9 +11,21 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        maven {
+            url "https://maven.google.com"
+        }
     }
 }
 
 task clean(type: Delete) {
     delete rootProject.buildDir
 }
+
+ext.minSdkVersionDeclared = 9
+ext.compileSdkVersionDeclared = 25
+ext.buildToolsVersionDeclared = '25.0.3'
+
+ext.supportLibVersion = '25.4.0'
+ext.espressoVersion = '3.0.0'
+ext.uiAutomatorVersion = '2.1.2'
+ext.baristaVersion = '1.5.3'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -3,38 +3,27 @@ apply plugin: 'com.novoda.bintray-release'
 apply from: '../config/android-quality.gradle'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.1"
+    compileSdkVersion compileSdkVersionDeclared
+    buildToolsVersion buildToolsVersionDeclared
 
     defaultConfig {
-        minSdkVersion 9
-        targetSdkVersion 25
-        versionCode 1
-        versionName "1.0"
+        minSdkVersion minSdkVersionDeclared
+        targetSdkVersion compileSdkVersionDeclared
     }
-}
 
-android {
     lintOptions {
         disable 'InvalidPackage'
     }
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
+    compile "com.android.support.test.espresso:espresso-core:$espressoVersion"
+    compile "com.android.support.test.espresso:espresso-contrib:$espressoVersion"
+    compile "com.android.support.test.uiautomator:uiautomator-v18:$uiAutomatorVersion"
 
-    compile('com.android.support.test.espresso:espresso-core:2.2.2', {
-        exclude group: 'com.android.support', module: 'support-annotations'
-    })
-    compile('com.android.support.test.espresso:espresso-contrib:2.0') {
-        exclude module: 'support-v4'
-    }
-
-    compile 'com.android.support.test.uiautomator:uiautomator-v18:2.1.2'
-
-    compile 'com.android.support:support-annotations:25.1.0'
-    compile 'com.android.support:support-core-ui:25.1.0'
-    compile 'com.android.support:recyclerview-v7:25.1.0'
+    compile "com.android.support:support-annotations:$supportLibVersion"
+    compile "com.android.support:support-core-ui:$supportLibVersion"
+    compile "com.android.support:recyclerview-v7:$supportLibVersion"
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.assertj:assertj-core:1.7.0'
@@ -44,7 +33,7 @@ publish {
     userOrg = 'schibstedspain'
     groupId = 'com.schibsted.spain'
     artifactId = 'barista'
-    publishVersion = '1.5.3'
+    publishVersion = baristaVersion
     desc = 'The guy who serves a great Espresso'
     website = 'https://github.com/SchibstedSpain/Barista'
 }

--- a/library/src/main/java/com/schibsted/spain/barista/custom/AutocompleteViewActions.java
+++ b/library/src/main/java/com/schibsted/spain/barista/custom/AutocompleteViewActions.java
@@ -11,7 +11,7 @@ import javax.annotation.Nonnull;
 import org.hamcrest.Matcher;
 
 import static android.support.test.espresso.action.ViewActions.actionWithAssertions;
-import static android.support.test.espresso.core.deps.guava.base.Preconditions.checkNotNull;
+import static android.support.test.espresso.core.internal.deps.guava.base.Preconditions.checkNotNull;
 import static android.support.test.espresso.matcher.ViewMatchers.isAssignableFrom;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static org.hamcrest.Matchers.allOf;

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -2,12 +2,12 @@ apply plugin: 'com.android.application'
 apply from: '../config/android-quality.gradle'
 
 android {
-  compileSdkVersion 25
-  buildToolsVersion "25.0.1"
+  compileSdkVersion compileSdkVersionDeclared
+  buildToolsVersion buildToolsVersionDeclared
   defaultConfig {
     applicationId "com.schibsted.spain.barista.sample"
-    minSdkVersion 9
-    targetSdkVersion 25
+    minSdkVersion minSdkVersionDeclared
+    targetSdkVersion compileSdkVersionDeclared
     versionCode 1
     versionName "1.0"
     testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -21,15 +21,12 @@ android {
 }
 
 dependencies {
-  compile fileTree(dir: 'libs', include: ['*.jar'])
-  compile 'com.android.support:appcompat-v7:25.1.0'
-  compile 'com.android.support:recyclerview-v7:25.1.0'
-  compile "com.android.support:design:25.1.0"
+  compile "com.android.support:appcompat-v7:$supportLibVersion"
+  compile "com.android.support:recyclerview-v7:$supportLibVersion"
+  compile "com.android.support:design:$supportLibVersion"
 
   testCompile 'junit:junit:4.12'
 
   androidTestCompile project(':library')
-  androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2.2'
-  androidTestCompile 'com.android.support:recyclerview-v7:25.1.0'
 
 }


### PR DESCRIPTION
I had to update the support library from 25.1.0 to 25.4.0, and change how we exclude some transitive dependencies.
I had to add the new Google Maven repository, where Espresso 3 is published.

I extracted all shared versions (libraries and sdks) to the main gradle file, because it was a nightmare trying to sync all versions from the library and sample.
This way future changes will be less painful.

With the migration to Espresso 3 there was just one code compilation error, because Espresso changed its included Guava package.