### PR TITLE
Exclude kotlin files from Findbugs

### DIFF
--- a/config/findbugs/findbugs-excludes.xml
+++ b/config/findbugs/findbugs-excludes.xml
@@ -1,6 +1,9 @@
 <FindBugsFilter>
     <!-- Fallback excludes file.  This file will be used when a project lacks a findbugs-excludes.xml file -->
     <Match>
+        <Source name="~.*\.kt"/>
+    </Match>
+    <Match>
         <Source name="~.*\.groovy" />
         <Or>
             <Field name="~__.*" />


### PR DESCRIPTION
This needs to happen.
Kotlin generates code that doesn't make findbugs happy, but we don't care about his feelings,
we like Kotlin better. He's the new kid in the hood and we're friends.

No, really. We've done 2 PRs with kotlin code and findbugs failed in both because of the bytecode generation.
It's not helpful for kotlin files.