### PR TITLE
Fixes click with scroll and multiple views

### DIFF
--- a/library/src/main/java/com/schibsted/spain/barista/BaristaClickActions.java
+++ b/library/src/main/java/com/schibsted/spain/barista/BaristaClickActions.java
@@ -1,18 +1,27 @@
 package com.schibsted.spain.barista;
 
 import android.support.test.espresso.AmbiguousViewMatcherException;
-import android.support.test.espresso.PerformException;
+import android.support.test.espresso.NoMatchingViewException;
 import android.support.test.espresso.action.ViewActions;
+import android.support.v4.widget.NestedScrollView;
 import android.view.View;
+import android.widget.HorizontalScrollView;
+import android.widget.ListView;
+import android.widget.ScrollView;
 import com.schibsted.spain.barista.androidresource.ResourceTypeChecker;
 import org.hamcrest.Matcher;
 
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.Espresso.pressBack;
+import static android.support.test.espresso.matcher.ViewMatchers.isAssignableFrom;
+import static android.support.test.espresso.matcher.ViewMatchers.isDescendantOfA;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
-import static com.schibsted.spain.barista.custom.NestedEnabledScrollToAction.scrollTo;
 import static com.schibsted.spain.barista.custom.DisplayedMatchers.displayedAnd;
+import static com.schibsted.spain.barista.custom.NestedEnabledScrollToAction.scrollTo;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.core.AnyOf.anyOf;
 
 public class BaristaClickActions {
 
@@ -32,15 +41,13 @@ public class BaristaClickActions {
 
   public static void click(Matcher<View> viewMatcher) {
     try {
-      scrollAndClickView(viewMatcher);
-    } catch (AmbiguousViewMatcherException multipleViewsMatched) {
-      try {
-        scrollAndClickDisplayedView(viewMatcher);
-      } catch (PerformException parentIsNotAnScrollView) {
-        clickDisplayedView(viewMatcher);
-      }
-    } catch (PerformException parentIsNotAnScrollView) {
       clickDisplayedView(viewMatcher);
+    } catch (NoMatchingViewException noMatchingError) {
+      try {
+        scrollAndClickView(viewMatcher);
+      } catch (AmbiguousViewMatcherException multipleViewsError) {
+        scrollAndClickDisplayedView(viewMatcher);
+      }
     }
   }
 
@@ -53,7 +60,18 @@ public class BaristaClickActions {
   }
 
   private static void scrollAndClickDisplayedView(Matcher<View> viewMatcher) {
-    onView(displayedAnd(viewMatcher)).perform(scrollTo(), ViewActions.click());
+    onView(allOf(
+        viewMatcher,
+        isDescendantOfA(allOf(
+            isDisplayed(),
+            anyOf(
+                isAssignableFrom(ScrollView.class),
+                isAssignableFrom(HorizontalScrollView.class),
+                isAssignableFrom(ListView.class),
+                isAssignableFrom(NestedScrollView.class)
+            )
+        ))
+    )).perform(scrollTo(), ViewActions.click());
   }
 
   private static void clickDisplayedView(Matcher<View> viewMatcher) {

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/ClickInsideViewPagerTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/ClickInsideViewPagerTest.java
@@ -27,4 +27,10 @@ public class ClickInsideViewPagerTest {
     click("Centered button");
     assertDisplayed(R.string.click);
   }
+
+  @Test
+  public void clickWorksAlsoWhenButtonIsRepeatedInMultipleViewPagerViews_belowScroll_byText() {
+    click("Really far away button");
+    assertDisplayed(R.string.click_far_away);
+  }
 }

--- a/sample/src/main/java/com/schibsted/spain/barista/sample/ViewPagerButtonFragment.java
+++ b/sample/src/main/java/com/schibsted/spain/barista/sample/ViewPagerButtonFragment.java
@@ -13,11 +13,20 @@ public class ViewPagerButtonFragment extends Fragment {
   public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
     final View root = inflater.inflate(R.layout.activity_centered_button, container, false);
     root.findViewById(R.id.button).setOnClickListener(new View.OnClickListener() {
-      @Override public void onClick(View view) {
+      @Override
+      public void onClick(View view) {
         TextView tv = (TextView) root.findViewById(R.id.textview);
         tv.setText(R.string.click);
       }
     });
+    root.findViewById(R.id.really_far_away_button).setOnClickListener(new View.OnClickListener() {
+      @Override
+      public void onClick(View view) {
+        TextView tv = (TextView) root.findViewById(R.id.textview);
+        tv.setText(R.string.click_far_away);
+      }
+    });
+
     return root;
   }
 }

--- a/sample/src/main/res/layout/activity_centered_button.xml
+++ b/sample/src/main/res/layout/activity_centered_button.xml
@@ -16,4 +16,23 @@
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:text="@string/hello_world"/>
+
+  <ScrollView
+      android:layout_width="match_parent"
+      android:layout_height="match_parent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+      <Button
+          android:id="@+id/really_far_away_button"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="1000dp"
+          android:text="@string/really_far_away_button"/>
+    </LinearLayout>
+  </ScrollView>
+
 </LinearLayout>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -14,5 +14,6 @@
   <string name="checked_checkbox">Checked checkbox</string>
   <string name="unchecked_checkbox">Unchecked checkbox</string>
   <string name="click">Click</string>
+  <string name="click_far_away">Click far away</string>
   <string name="refreshing">I am refreshing!</string>
 </resources>


### PR DESCRIPTION
This magic behavior of the click method was implemented, but didn't have any test covering it.
And guess what. It didn't work!

The `scrollAndClickDisplayedView` was using the `isDisplayed` condition to filter the button from the current viewpager. But since the button is below a scroll, isDisplayed would never match.

I created the missing test to reproduce it, and fixed the method by using a more complex view matcher. The `isDisplayed` filter is applied on the scrollable ancestor of the button, and not the button itself.

I had to change the try/catch logic to make it work as expected after the change.