### PR TITLE
Add focus assertions

### DIFF
--- a/library/src/main/java/com/schibsted/spain/barista/BaristaAssertions.java
+++ b/library/src/main/java/com/schibsted/spain/barista/BaristaAssertions.java
@@ -15,6 +15,7 @@ import static android.support.test.espresso.assertion.ViewAssertions.doesNotExis
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.contrib.DrawerMatchers.isClosed;
 import static android.support.test.espresso.contrib.DrawerMatchers.isOpen;
+import static android.support.test.espresso.matcher.ViewMatchers.hasFocus;
 import static android.support.test.espresso.matcher.ViewMatchers.isChecked;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static android.support.test.espresso.matcher.ViewMatchers.isEnabled;
@@ -164,6 +165,14 @@ public class BaristaAssertions {
 
   public static void assertDrawable(@IdRes int id, @DrawableRes int drawable) {
     onView(withId(id)).check(matches(withDrawable(drawable)));
+  }
+
+  public static void assertHasFocus(@IdRes int id) {
+    onView(withId(id)).check(matches(hasFocus()));
+  }
+
+  public static void assertNotHasFocus(@IdRes int id) {
+    onView(withId(id)).check(matches(not(hasFocus())));
   }
 
   private static boolean isIdResource(int id) {

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertionsTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertionsTest.java
@@ -13,8 +13,10 @@ import static com.schibsted.spain.barista.BaristaAssertions.assertDisabled;
 import static com.schibsted.spain.barista.BaristaAssertions.assertDisplayed;
 import static com.schibsted.spain.barista.BaristaAssertions.assertDrawable;
 import static com.schibsted.spain.barista.BaristaAssertions.assertEnabled;
+import static com.schibsted.spain.barista.BaristaAssertions.assertHasFocus;
 import static com.schibsted.spain.barista.BaristaAssertions.assertNotDisplayed;
 import static com.schibsted.spain.barista.BaristaAssertions.assertNotExist;
+import static com.schibsted.spain.barista.BaristaAssertions.assertNotHasFocus;
 import static com.schibsted.spain.barista.BaristaAssertions.assertThatBackButtonClosesTheApp;
 import static com.schibsted.spain.barista.BaristaAssertions.assertUnchecked;
 import static junit.framework.Assert.fail;
@@ -278,5 +280,15 @@ public class AssertionsTest {
   @Test(expected = AssertionFailedError.class)
   public void checkDifferentDrawable() throws Exception {
     assertDrawable(R.id.image_view, R.drawable.ic_action_menu);
+  }
+
+  @Test
+  public void checkEditTextHasFocus() {
+    assertHasFocus(R.id.edittext_with_focus);
+  }
+
+  @Test
+  public void checkEditTextNotHasFocus() {
+    assertNotHasFocus(R.id.edittext_without_focus);
   }
 }

--- a/sample/src/main/java/com/schibsted/spain/barista/sample/SomeViewsWithDifferentVisibilitesActivity.java
+++ b/sample/src/main/java/com/schibsted/spain/barista/sample/SomeViewsWithDifferentVisibilitesActivity.java
@@ -9,5 +9,7 @@ public class SomeViewsWithDifferentVisibilitesActivity extends AppCompatActivity
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
     setContentView(R.layout.activity_main);
+
+    findViewById(R.id.edittext_with_focus).requestFocus();
   }
 }

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -82,6 +82,17 @@
       android:id="@+id/image_view"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      android:src="@drawable/ic_barista"
-      />
+      android:src="@drawable/ic_barista"/>
+
+  <EditText
+      android:id="@+id/edittext_with_focus"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:hint="EditText with focus"/>
+
+  <EditText
+      android:id="@+id/edittext_without_focus"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:hint="EditText without focus"/>
 </LinearLayout>


### PR DESCRIPTION
This PR includes `assertHasFocus` and `assertHasNotFocus` as requested on the issue #95 

The EditTexts used to test the two new assertions have been added to the `SomeViewsWithDifferentVisibilitesActivity`. 
I am not sure if it's the best place as it talks about visibility, but I thought it's not worth to add a new Activity just to add this two tests.