### PR TITLE
Add focus assertions

### DIFF
--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaAssertions.kt
@@ -183,12 +183,22 @@ object BaristaAssertions {
     }
 
     @JvmStatic
-    fun assertHasFocus(@IdRes id: Int) {
-        onView(withId(id)).check(matches(hasFocus()))
+    fun assertHasFocus(@IdRes resId: Int) {
+        onView(resId.resourceMatcher()).check(matches(hasFocus()))
     }
 
     @JvmStatic
-    fun assertHasNotFocus(@IdRes id: Int) {
-        onView(withId(id)).check(matches(not(hasFocus())))
+    fun assertHasNotFocus(@IdRes resId: Int) {
+        onView(resId.resourceMatcher()).check(matches(not(hasFocus())))
+    }
+
+    @JvmStatic
+    fun assertHasFocus(text: String) {
+        onView(withText(text)).check(matches(hasFocus()))
+    }
+
+    @JvmStatic
+    fun assertHasNotFocus(text: String) {
+        onView(withText(text)).check(matches(not(hasFocus())))
     }
 }

--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaAssertions.kt
@@ -15,13 +15,13 @@ import android.support.test.espresso.contrib.DrawerMatchers.isOpen
 import android.support.test.espresso.matcher.ViewMatchers.*
 import android.support.v4.view.GravityCompat
 import android.view.View
-import com.schibsted.spain.barista.internal.matcher.RecyclerViewItemCountAssertion
 import com.schibsted.spain.barista.internal.failurehandler.RethrowingFailureHandler
 import com.schibsted.spain.barista.internal.failurehandler.SpyFailureHandler
 import com.schibsted.spain.barista.internal.failurehandler.description
 import com.schibsted.spain.barista.internal.matcher.DisplayedMatchers.displayedWithId
 import com.schibsted.spain.barista.internal.matcher.DrawableMatchers.withDrawable
 import com.schibsted.spain.barista.internal.matcher.HelperMatchers.firstViewOf
+import com.schibsted.spain.barista.internal.matcher.RecyclerViewItemCountAssertion
 import com.schibsted.spain.barista.internal.util.resourceMatcher
 import org.hamcrest.Matcher
 import org.hamcrest.Matchers.allOf
@@ -183,22 +183,22 @@ object BaristaAssertions {
     }
 
     @JvmStatic
-    fun assertHasFocus(@IdRes resId: Int) {
+    fun assertFocused(@IdRes resId: Int) {
         onView(resId.resourceMatcher()).check(matches(hasFocus()))
     }
 
     @JvmStatic
-    fun assertHasNotFocus(@IdRes resId: Int) {
+    fun assertNotFocused(@IdRes resId: Int) {
         onView(resId.resourceMatcher()).check(matches(not(hasFocus())))
     }
 
     @JvmStatic
-    fun assertHasFocus(text: String) {
+    fun assertFocused(text: String) {
         onView(withText(text)).check(matches(hasFocus()))
     }
 
     @JvmStatic
-    fun assertHasNotFocus(text: String) {
+    fun assertNotFocused(text: String) {
         onView(withText(text)).check(matches(not(hasFocus())))
     }
 }

--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaAssertions.kt
@@ -181,4 +181,14 @@ object BaristaAssertions {
     fun assertDrawable(@IdRes id: Int, @DrawableRes drawable: Int) {
         onView(withId(id)).check(matches(withDrawable(drawable)))
     }
+
+    @JvmStatic
+    fun assertHasFocus(@IdRes id: Int) {
+        onView(withId(id)).check(matches(hasFocus()))
+    }
+
+    @JvmStatic
+    fun assertHasNotFocus(@IdRes id: Int) {
+        onView(withId(id)).check(matches(not(hasFocus())))
+    }
 }

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertionsTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertionsTest.java
@@ -13,10 +13,10 @@ import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertDisa
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertDisplayed;
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertDrawable;
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertEnabled;
-import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertHasFocus;
-import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertHasNotFocus;
+import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertFocused;
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertNotDisplayed;
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertNotExist;
+import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertNotFocused;
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertThatBackButtonClosesTheApp;
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertUnchecked;
 import static junit.framework.Assert.fail;
@@ -266,12 +266,12 @@ public class AssertionsTest {
     } catch (BaristaArgumentTypeException expected) {
     }
     try {
-      assertHasFocus(R.color.colorAccent);
+      assertFocused(R.color.colorAccent);
       fail();
     } catch (BaristaArgumentTypeException expected) {
     }
     try {
-      assertHasNotFocus(R.color.colorAccent);
+      assertNotFocused(R.color.colorAccent);
       fail();
     } catch (BaristaArgumentTypeException expected) {
     }
@@ -294,15 +294,15 @@ public class AssertionsTest {
 
   @Test
   public void checkViewHasFocus() throws Exception {
-    assertHasFocus(R.id.edittext_with_focus);
-    assertHasFocus(R.string.edittext_with_focus);
-    assertHasFocus("EditText with focus");
+    assertFocused(R.id.edittext_with_focus);
+    assertFocused(R.string.edittext_with_focus);
+    assertFocused("EditText with focus");
   }
 
   @Test
   public void checkViewHasNotFocus() throws Exception {
-    assertHasNotFocus(R.id.edittext_without_focus);
-    assertHasNotFocus(R.string.edittext_with_no_focus);
-    assertHasNotFocus("EditText with no focus");
+    assertNotFocused(R.id.edittext_without_focus);
+    assertNotFocused(R.string.edittext_with_no_focus);
+    assertNotFocused("EditText with no focus");
   }
 }

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertionsTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertionsTest.java
@@ -13,6 +13,8 @@ import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertDisa
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertDisplayed;
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertDrawable;
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertEnabled;
+import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertHasFocus;
+import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertHasNotFocus;
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertNotDisplayed;
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertNotExist;
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertThatBackButtonClosesTheApp;
@@ -278,5 +280,15 @@ public class AssertionsTest {
   @Test(expected = AssertionFailedError.class)
   public void checkDifferentDrawable() throws Exception {
     assertDrawable(R.id.image_view, R.drawable.ic_action_menu);
+  }
+
+  @Test
+  public void checkViewHasFocus() throws Exception {
+    assertHasFocus(R.id.edittext_with_focus);
+  }
+
+  @Test
+  public void checkViewHasNotFocus() throws Exception {
+    assertHasNotFocus(R.id.edittext_without_focus);
   }
 }

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertionsTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertionsTest.java
@@ -265,6 +265,16 @@ public class AssertionsTest {
       fail();
     } catch (BaristaArgumentTypeException expected) {
     }
+    try {
+      assertHasFocus(R.color.colorAccent);
+      fail();
+    } catch (BaristaArgumentTypeException expected) {
+    }
+    try {
+      assertHasNotFocus(R.color.colorAccent);
+      fail();
+    } catch (BaristaArgumentTypeException expected) {
+    }
   }
 
   @Test
@@ -285,10 +295,14 @@ public class AssertionsTest {
   @Test
   public void checkViewHasFocus() throws Exception {
     assertHasFocus(R.id.edittext_with_focus);
+    assertHasFocus(R.string.edittext_with_focus);
+    assertHasFocus("EditText with focus");
   }
 
   @Test
   public void checkViewHasNotFocus() throws Exception {
     assertHasNotFocus(R.id.edittext_without_focus);
+    assertHasNotFocus(R.string.edittext_with_no_focus);
+    assertHasNotFocus("EditText with no focus");
   }
 }

--- a/sample/src/main/java/com/schibsted/spain/barista/sample/SomeViewsWithDifferentVisibilitesActivity.java
+++ b/sample/src/main/java/com/schibsted/spain/barista/sample/SomeViewsWithDifferentVisibilitesActivity.java
@@ -9,5 +9,7 @@ public class SomeViewsWithDifferentVisibilitesActivity extends AppCompatActivity
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
     setContentView(R.layout.activity_main);
+
+    findViewById(R.id.edittext_with_focus).requestFocus();
   }
 }

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -84,4 +84,16 @@
       android:layout_height="wrap_content"
       android:src="@drawable/ic_barista"
       />
+
+  <EditText
+      android:id="@+id/edittext_with_focus"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:hint="EditText with focus"/>
+
+  <EditText
+      android:id="@+id/edittext_without_focus"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:hint="EditText without focus"/>
 </LinearLayout>

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -89,11 +89,11 @@
       android:id="@+id/edittext_with_focus"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:hint="EditText with focus"/>
+      android:text="@string/edittext_with_focus"/>
 
   <EditText
       android:id="@+id/edittext_without_focus"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:hint="EditText without focus"/>
+      android:text="@string/edittext_with_no_focus"/>
 </LinearLayout>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -16,4 +16,6 @@
   <string name="click">Click</string>
   <string name="click_far_away">Click far away</string>
   <string name="refreshing">I am refreshing!</string>
+  <string name="edittext_with_focus">EditText with focus</string>
+  <string name="edittext_with_no_focus">EditText with no focus</string>
 </resources>


### PR DESCRIPTION
This PR includes `assertHasFocus` and `assertHasNotFocus` as requested on the issue #95

The EditTexts used to test the two new assertions have been added to the SomeViewsWithDifferentVisibilitesActivity.

I am not sure if it's the best place as it talks about visibility, but I thought it's not worth to add a new Activity just to add this two tests.