### PR TITLE
 Add assertText assertion to check that a given text is shown in a given View

### DIFF
--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaAssertions.kt
@@ -40,6 +40,11 @@ object BaristaAssertions {
         assertDisplayed(withText(text))
     }
 
+    @JvmStatic
+    fun assertDisplayed(@IdRes resId: Int, text: String) {
+        onView(resId.resourceMatcher()).check(matches(withText(text)));
+    }
+
     private fun assertDisplayed(matcher: Matcher<View>) {
         val spyFailureHandler = SpyFailureHandler()
         try {
@@ -200,10 +205,5 @@ object BaristaAssertions {
     @JvmStatic
     fun assertNotFocused(text: String) {
         onView(withText(text)).check(matches(not(hasFocus())))
-    }
-
-    @JvmStatic
-    fun assertText(@IdRes resId: Int, text: String) {
-        onView(resId.resourceMatcher()).check(matches(withText(text)));
     }
 }

--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaAssertions.kt
@@ -201,4 +201,9 @@ object BaristaAssertions {
     fun assertNotFocused(text: String) {
         onView(withText(text)).check(matches(not(hasFocus())))
     }
+
+    @JvmStatic
+    fun assertText(@IdRes resId: Int, text: String) {
+        onView(resId.resourceMatcher()).check(matches(withText(text)));
+    }
 }

--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaAssertions.kt
@@ -42,7 +42,7 @@ object BaristaAssertions {
 
     @JvmStatic
     fun assertDisplayed(@IdRes resId: Int, text: String) {
-        onView(resId.resourceMatcher()).check(matches(withText(text)));
+        onView(withId(resId)).check(matches(withText(text)))
     }
 
     private fun assertDisplayed(matcher: Matcher<View>) {

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertionsTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertionsTest.java
@@ -17,7 +17,7 @@ import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertFocu
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertNotDisplayed;
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertNotExist;
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertNotFocused;
-import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertText;
+import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertDisplayed;
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertThatBackButtonClosesTheApp;
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertUnchecked;
 import static junit.framework.Assert.fail;
@@ -62,6 +62,11 @@ public class AssertionsTest {
 
     assertDisplayed("Repeated");
     assertDisplayed(R.string.repeated);
+  }
+
+  @Test
+  public void checkExpectedText() throws Exception {
+    assertDisplayed(R.id.visible_view, "Hello world!");
   }
 
   @Test
@@ -277,7 +282,7 @@ public class AssertionsTest {
     } catch (BaristaArgumentTypeException expected) {
     }
     try {
-      assertText(R.color.colorAccent, "Dummy text");
+      assertDisplayed(R.color.colorAccent, "Dummy text");
       fail();
     } catch (BaristaArgumentTypeException expected) {
     }
@@ -310,10 +315,5 @@ public class AssertionsTest {
     assertNotFocused(R.id.edittext_without_focus);
     assertNotFocused(R.string.edittext_with_no_focus);
     assertNotFocused("EditText with no focus");
-  }
-
-  @Test
-  public void checkExpectedText() throws Exception {
-    assertText(R.id.visible_view, "Hello world!");
   }
 }

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertionsTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertionsTest.java
@@ -17,6 +17,7 @@ import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertFocu
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertNotDisplayed;
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertNotExist;
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertNotFocused;
+import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertText;
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertThatBackButtonClosesTheApp;
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertUnchecked;
 import static junit.framework.Assert.fail;
@@ -275,6 +276,11 @@ public class AssertionsTest {
       fail();
     } catch (BaristaArgumentTypeException expected) {
     }
+    try {
+      assertText(R.color.colorAccent, "Dummy text");
+      fail();
+    } catch (BaristaArgumentTypeException expected) {
+    }
   }
 
   @Test
@@ -304,5 +310,10 @@ public class AssertionsTest {
     assertNotFocused(R.id.edittext_without_focus);
     assertNotFocused(R.string.edittext_with_no_focus);
     assertNotFocused("EditText with no focus");
+  }
+
+  @Test
+  public void checkExpectedText() throws Exception {
+    assertText(R.id.visible_view, "Hello world!");
   }
 }

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertionsTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertionsTest.java
@@ -285,11 +285,6 @@ public class AssertionsTest {
       fail();
     } catch (BaristaArgumentTypeException expected) {
     }
-    try {
-      assertDisplayed(R.color.colorAccent, "Dummy text");
-      fail();
-    } catch (BaristaArgumentTypeException expected) {
-    }
   }
 
   @Test

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertionsTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertionsTest.java
@@ -68,6 +68,11 @@ public class AssertionsTest {
     assertDisplayed(R.id.visible_view, "Hello world!");
   }
 
+  @Test(expected = AssertionFailedError.class)
+  public void checkExpectedText_failsWhenTextIsNotTheExpected() throws Exception {
+    assertDisplayed(R.id.visible_view, "This is not the text you are looking for");
+  }
+
   @Test
   public void checkInvisibleViews() {
     assertNotDisplayed(R.id.invisible_view);

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertionsTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertionsTest.java
@@ -17,7 +17,6 @@ import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertFocu
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertNotDisplayed;
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertNotExist;
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertNotFocused;
-import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertDisplayed;
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertThatBackButtonClosesTheApp;
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertUnchecked;
 import static junit.framework.Assert.fail;


### PR DESCRIPTION
Add assertion 
`assertText(R.id.widget, "expected text")`

This assertion was requested on issue #120 