### PR TITLE
 Create FlakyTestRule independent from ActivityTestRule

### DIFF
--- a/library/src/main/java/com/schibsted/spain/barista/rule/BaristaRule.java
+++ b/library/src/main/java/com/schibsted/spain/barista/rule/BaristaRule.java
@@ -2,10 +2,11 @@ package com.schibsted.spain.barista.rule;
 
 import android.app.Activity;
 import android.content.Intent;
+import android.support.test.rule.ActivityTestRule;
 import com.schibsted.spain.barista.rule.cleardata.ClearDatabaseRule;
 import com.schibsted.spain.barista.rule.cleardata.ClearFilesRule;
 import com.schibsted.spain.barista.rule.cleardata.ClearPreferencesRule;
-import com.schibsted.spain.barista.rule.flaky.FlakyActivityTestRule;
+import com.schibsted.spain.barista.rule.flaky.FlakyTestRule;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
@@ -24,21 +25,26 @@ public class BaristaRule<T extends Activity> implements TestRule {
   private final ClearPreferencesRule clearPreferencesRule;
   private final ClearDatabaseRule clearDatabaseRule;
   private final ClearFilesRule clearFilesRule;
-  private final FlakyActivityTestRule<T> activityTestRule;
+  private final FlakyTestRule flakyTestRule;
+  private final ActivityTestRule<T> activityTestRule;
 
   private BaristaRule(Class<T> activityClass) {
     this.clearDatabaseRule = new ClearDatabaseRule();
     this.clearPreferencesRule = new ClearPreferencesRule();
     this.clearFilesRule = new ClearFilesRule();
-    this.activityTestRule = new FlakyActivityTestRule<>(activityClass,
-        INITIAL_TOUCH_MODE_ENABLED,
-        LAUNCH_ACTIVITY_AUTOMATICALLY)
+    this.flakyTestRule = new FlakyTestRule()
         .allowFlakyAttemptsByDefault(DEFAULT_FLAKY_ATTEMPTS);
+    this.activityTestRule = new ActivityTestRule<>(activityClass,
+        INITIAL_TOUCH_MODE_ENABLED,
+        LAUNCH_ACTIVITY_AUTOMATICALLY);
   }
 
   @Override
   public Statement apply(Statement base, Description description) {
-    return RuleChain.outerRule(activityTestRule)
+    return RuleChain.outerRule(flakyTestRule)
+        // ↓ All rules below flakyTestRule will be repeated
+        .around(activityTestRule)
+        // ↓ All rules below activityTestRule will execute before launching the activity
         .around(clearPreferencesRule)
         .around(clearDatabaseRule)
         .around(clearFilesRule)
@@ -53,7 +59,7 @@ public class BaristaRule<T extends Activity> implements TestRule {
     activityTestRule.launchActivity(startIntent);
   }
 
-  public FlakyActivityTestRule<T> getActivityTestRule() {
+  public ActivityTestRule<T> getActivityTestRule() {
     return activityTestRule;
   }
 }

--- a/library/src/main/java/com/schibsted/spain/barista/rule/flaky/AllowFlaky.java
+++ b/library/src/main/java/com/schibsted/spain/barista/rule/flaky/AllowFlaky.java
@@ -7,10 +7,10 @@ import java.lang.annotation.Target;
 /**
  * It let's flaky tests pass.
  * <br>
- * This annotation together with {@link FlakyActivityTestRule} repeats the annotated test several times, and makes the test pass if any of
+ * This annotation together with {@link FlakyTestRule} repeats the annotated test several times, and makes the test pass if any of
  * the executions passed. It's the opposite of {@link Repeat}.
  * <br>
- * You can use {@link FlakyActivityTestRule#allowFlakyAttemptsByDefault(int)} instead.
+ * You can use {@link FlakyTestRule#allowFlakyAttemptsByDefault(int)} to avoid repeating the annotation on every test method.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({

--- a/library/src/main/java/com/schibsted/spain/barista/rule/flaky/FlakyActivityTestRule.java
+++ b/library/src/main/java/com/schibsted/spain/barista/rule/flaky/FlakyActivityTestRule.java
@@ -2,17 +2,21 @@ package com.schibsted.spain.barista.rule.flaky;
 
 import android.app.Activity;
 import android.support.test.rule.ActivityTestRule;
-import com.schibsted.spain.barista.rule.flaky.internal.FlakyActivityStatementBuilder;
+import com.schibsted.spain.barista.rule.BaristaRule;
+import com.schibsted.spain.barista.rule.flaky.internal.FlakyStatementBuilder;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
 /**
  * This is a subclass of {@link ActivityTestRule} that enables repetition of flaky tests using the annotations {@link AllowFlaky} and {@link
  * Repeat}. Check out the docs on each one to see how they behave.
+ *
+ * @deprecated Use a {@link FlakyTestRule} in combination with {@link ActivityTestRule}, or use {@link BaristaRule}.
  */
+@Deprecated
 public class FlakyActivityTestRule<T extends Activity> extends ActivityTestRule<T> {
 
-  private final FlakyActivityStatementBuilder statementBuilder = new FlakyActivityStatementBuilder();
+  private final FlakyStatementBuilder statementBuilder = new FlakyStatementBuilder();
 
   public FlakyActivityTestRule(Class<T> activityClass) {
     super(activityClass);
@@ -34,7 +38,7 @@ public class FlakyActivityTestRule<T extends Activity> extends ActivityTestRule<
    * <br>
    * The behavior will be overridden with {@link Repeat} or {@link AllowFlaky}.
    */
-  public FlakyActivityTestRule<T> allowFlakyAttemptsByDefault(int defaultAttempts) {
+  public FlakyActivityTestRule<T> allowFlakyByDefault(int defaultAttempts) {
     statementBuilder.allowFlakyAttemptsByDefault(defaultAttempts);
     return this;
   }

--- a/library/src/main/java/com/schibsted/spain/barista/rule/flaky/FlakyTestRule.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/rule/flaky/FlakyTestRule.kt
@@ -1,0 +1,39 @@
+package com.schibsted.spain.barista.rule.flaky
+
+import com.schibsted.spain.barista.rule.flaky.internal.FlakyStatementBuilder
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+
+/**
+ * This TestRule enables repetition of flaky tests using the annotations @[AllowFlaky] and @[Repeat].
+ * Check out the docs on each one to see how they behave.
+ *
+ * NOTE: Rule ordering is important. Use a [org.junit.rules.RuleChain] to make sure this is the outermost rule,
+ * otherwise you might get unexpected results.
+ */
+class FlakyTestRule : TestRule {
+
+    private val flakyStatementBuilder = FlakyStatementBuilder()
+
+    /**
+     * Utility method to use @[AllowFlaky] by default in all test methods.
+     * <br></br>
+     * Use this method when constructing the Rule to apply a default behavior of @[AllowFlaky] without having to add the annotation to
+     * each test. Use it wisely when your tests are very flaky, something quite common with Espresso.
+     * <br></br>
+     * The default behavior can be overridden with [Repeat] or [AllowFlaky].
+     */
+    fun allowFlakyAttemptsByDefault(defaultAttempts: Int): FlakyTestRule {
+        flakyStatementBuilder.allowFlakyAttemptsByDefault(defaultAttempts)
+        return this
+    }
+
+    override fun apply(base: Statement, description: Description): Statement {
+        return flakyStatementBuilder
+                .setBase(base)
+                .setDescription(description)
+                .build()
+    }
+
+}

--- a/library/src/main/java/com/schibsted/spain/barista/rule/flaky/Repeat.java
+++ b/library/src/main/java/com/schibsted/spain/barista/rule/flaky/Repeat.java
@@ -7,7 +7,7 @@ import java.lang.annotation.Target;
 /**
  * It avoids flaky test from passing.
  * <br>
- * This annotation together with {@link FlakyActivityTestRule} repeats the annotated test several times, and makes the test fail if any of
+ * This annotation together with {@link FlakyTestRule} repeats the annotated test several times, and makes the test fail if any of
  * the executions failed. It's the opposite of {@link AllowFlaky}.
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/library/src/main/java/com/schibsted/spain/barista/rule/flaky/internal/FlakyStatementBuilder.java
+++ b/library/src/main/java/com/schibsted/spain/barista/rule/flaky/internal/FlakyStatementBuilder.java
@@ -5,24 +5,24 @@ import com.schibsted.spain.barista.rule.flaky.Repeat;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
-public class FlakyActivityStatementBuilder {
+public class FlakyStatementBuilder {
 
   private Statement base;
   private Description description;
   private boolean useAllowFlakyByDefault = false;
   private int defaultAllowFlakyAttempts = 0;
 
-  public FlakyActivityStatementBuilder setBase(Statement base) {
+  public FlakyStatementBuilder setBase(Statement base) {
     this.base = base;
     return this;
   }
 
-  public FlakyActivityStatementBuilder setDescription(Description description) {
+  public FlakyStatementBuilder setDescription(Description description) {
     this.description = description;
     return this;
   }
 
-  public FlakyActivityStatementBuilder allowFlakyAttemptsByDefault(int attempts) {
+  public FlakyStatementBuilder allowFlakyAttemptsByDefault(int attempts) {
     useAllowFlakyByDefault = true;
     defaultAllowFlakyAttempts = attempts;
     return this;

--- a/library/src/test/java/com/schibsted/spain/barista/rule/flaky/FlakyStatementBuilderTest.java
+++ b/library/src/test/java/com/schibsted/spain/barista/rule/flaky/FlakyStatementBuilderTest.java
@@ -1,7 +1,7 @@
 package com.schibsted.spain.barista.rule.flaky;
 
 import com.schibsted.spain.barista.rule.flaky.internal.AllowFlakyStatement;
-import com.schibsted.spain.barista.rule.flaky.internal.FlakyActivityStatementBuilder;
+import com.schibsted.spain.barista.rule.flaky.internal.FlakyStatementBuilder;
 import com.schibsted.spain.barista.rule.flaky.internal.RepeatStatement;
 import java.lang.annotation.Annotation;
 import org.junit.Test;
@@ -11,7 +11,7 @@ import org.junit.runners.model.Statement;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertTrue;
 
-public class FlakyActivityStatementBuilderTest {
+public class FlakyStatementBuilderTest {
 
   private static final String CLASS = "class name";
   private static final String TEST = "test name";
@@ -59,7 +59,7 @@ public class FlakyActivityStatementBuilderTest {
     Statement baseStatement = new SomeStatement();
     Description description = Description.EMPTY;
 
-    Statement resultStatement = new FlakyActivityStatementBuilder()
+    Statement resultStatement = new FlakyStatementBuilder()
         .setBase(baseStatement)
         .setDescription(description)
         .allowFlakyAttemptsByDefault(5)
@@ -70,7 +70,7 @@ public class FlakyActivityStatementBuilderTest {
 
   //region Shortcut methods
   private Statement createStatement(Statement baseStatement, Description description) {
-    return new FlakyActivityStatementBuilder()
+    return new FlakyStatementBuilder()
         .setBase(baseStatement)
         .setDescription(description)
         .build();

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/FlakyTestRuleTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/FlakyTestRuleTest.java
@@ -1,29 +1,32 @@
 package com.schibsted.spain.barista.sample;
 
+import android.support.test.rule.ActivityTestRule;
 import com.schibsted.spain.barista.rule.flaky.AllowFlaky;
-import com.schibsted.spain.barista.rule.flaky.FlakyActivityTestRule;
+import com.schibsted.spain.barista.rule.flaky.FlakyTestRule;
 import com.schibsted.spain.barista.rule.flaky.Repeat;
 import java.util.Random;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
 
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 
-public class FlakyRuleTest {
+public class FlakyTestRuleTest {
 
   private final Random random = new Random();
 
-  @Rule
-  public FlakyActivityTestRule<HelloWorldActivity> activityRule = new FlakyActivityTestRule<>(HelloWorldActivity.class, true, false);
+  private ActivityTestRule<HelloWorldActivity> activityRule = new ActivityTestRule<>(HelloWorldActivity.class, true, false);
+  private FlakyTestRule flakyRule = new FlakyTestRule()
+      .allowFlakyAttemptsByDefault(1);
 
   @Rule
-  public FlakyActivityTestRule<HelloWorldActivity> activityRuleWithDefaultFlaky =
-      new FlakyActivityTestRule<>(HelloWorldActivity.class, true, false)
-          .allowFlakyAttemptsByDefault(5);
+  public RuleChain chain = RuleChain.outerRule(flakyRule)
+      .around(activityRule);
+
 
   // WARNING: this test must fail when run
   @Test
@@ -40,20 +43,9 @@ public class FlakyRuleTest {
   }
 
   @Test
-  @AllowFlaky(attempts = 5)
+  @AllowFlaky(attempts = 10)
   public void someFlakyTest() throws Exception {
     activityRule.launchActivity(null);
-
-    onView(withId(R.id.some_view)).check(matches(isDisplayed()));
-
-    if (random.nextFloat() > 0.3) {
-      throw new TestException("Random test failure");
-    }
-  }
-
-  @Test
-  public void someDefaultFlakyTest() throws Exception {
-    activityRuleWithDefaultFlaky.launchActivity(null);
 
     onView(withId(R.id.some_view)).check(matches(isDisplayed()));
 

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/ViewPagerTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/ViewPagerTest.java
@@ -1,22 +1,21 @@
 package com.schibsted.spain.barista.sample;
 
+import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
-import com.schibsted.spain.barista.rule.flaky.FlakyActivityTestRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertDisplayed;
 import static com.schibsted.spain.barista.action.BaristaViewPagerActions.swipeViewPagerBack;
 import static com.schibsted.spain.barista.action.BaristaViewPagerActions.swipeViewPagerForward;
+import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertDisplayed;
 
 @RunWith(AndroidJUnit4.class)
 public class ViewPagerTest {
 
   @Rule
-  public FlakyActivityTestRule<ViewPagerWithTwoDifferentPagesActivity> activityRule =
-      new FlakyActivityTestRule<>(ViewPagerWithTwoDifferentPagesActivity.class)
-          .allowFlakyAttemptsByDefault(10);
+  public ActivityTestRule<ViewPagerWithTwoDifferentPagesActivity> activityRule =
+      new ActivityTestRule<>(ViewPagerWithTwoDifferentPagesActivity.class);
 
   @Test
   public void checkSwipeForward() {

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/ViewPagerWithoutIdTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/ViewPagerWithoutIdTest.java
@@ -1,22 +1,21 @@
 package com.schibsted.spain.barista.sample;
 
+import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
-import com.schibsted.spain.barista.rule.flaky.FlakyActivityTestRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertDisplayed;
 import static com.schibsted.spain.barista.action.BaristaViewPagerActions.swipeViewPagerBack;
 import static com.schibsted.spain.barista.action.BaristaViewPagerActions.swipeViewPagerForward;
+import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertDisplayed;
 
 @RunWith(AndroidJUnit4.class)
 public class ViewPagerWithoutIdTest {
 
   @Rule
-  public FlakyActivityTestRule<ViewPagerWithTwoDifferentPagesActivity> activityRule =
-      new FlakyActivityTestRule<>(ViewPagerWithTwoDifferentPagesActivity.class)
-          .allowFlakyAttemptsByDefault(10);
+  public ActivityTestRule<ViewPagerWithTwoDifferentPagesActivity> activityRule =
+      new ActivityTestRule<>(ViewPagerWithTwoDifferentPagesActivity.class);
 
   @Test
   public void checkSwipeForward() {


### PR DESCRIPTION
Solves #131

This change decouples FlakyTestRule from ActivityTestRule. We prefer composition over inheritance for rules.

I left the FlakyActivityTestRule as deprecated. Even though we're moving to Barista 2.0 with breaking changes, this one has a really low cost to maintain. We'll remove it in the future, reducing the migration impact for Barista 2.0.

