### PR TITLE
Readme for 2.0

### DIFF
--- a/MIGRATION-2.0.md
+++ b/MIGRATION-2.0.md
@@ -30,7 +30,7 @@ com.schibsted.spain.barista.rule
 - `ListView` or `RecyclerView` id is optional when only one instance of `ListView` or `RecyclerView` is displayed in the hierarchy. ([#146](https://github.com/SchibstedSpain/Barista/pull/146)
 - Drawer id on drawer actions and assertions is optional when only one DrawerLayout is present in the hierarchy. ([#161](https://github.com/SchibstedSpain/Barista/pull/161))
 - Drawer actions and assertions allow using non-default gravity with `openDrawerWithGravity()`, `closeDrawerWithGravity()`, `assertDrawerIsOpenWithGravity()` and `assertDrawerIsClosedWithGravity()`. ([#161](https://github.com/SchibstedSpain/Barista/pull/161))
-- `SwipeRefreshLayout` id is not optional in `refresh()` method when only one `SwipeRefreshLayout` is present in the hierarchy. ([#150](https://github.com/SchibstedSpain/Barista/pull/150))
+- `SwipeRefreshLayout` id is now optional in `refresh()` method when only one `SwipeRefreshLayout` is present in the hierarchy. ([#150](https://github.com/SchibstedSpain/Barista/pull/150))
 - Added `assertFocused()` and `assertNotFocused()` methods.
 ([#157](https://github.com/SchibstedSpain/Barista/pull/157))
 - Added `assertDisplayed(id, text)` to check some text in a specific view. ([#150](https://github.com/SchibstedSpain/Barista/pull/150))

--- a/MIGRATION-2.0.md
+++ b/MIGRATION-2.0.md
@@ -1,0 +1,43 @@
+# Migration guide from Barista 1.x to 2.0
+
+You just updated Barista dependency from 1.x to 2.0 and everything is in red?
+We did some breaking changes to improve our public API, and that's why we increased our major version.
+
+But fear not, here are a list of breaking changes and how to solve them:
+
+## Packages and classes
+We changed our Action classes to Interaction, to avoid confusion with Espresso ViewAction. ([#132](https://github.com/SchibstedSpain/Barista/issues/132))
+
+We moved most classes to different packages for better code organisation. You will find your missing imports in one of these public packages:
+```
+com.schibsted.spain.barista.assertion
+com.schibsted.spain.barista.interaction
+com.schibsted.spain.barista.rule
+```
+
+## Changed methods
+- `click()` methods have been renamed to `clickOn()`. ([#100](https://github.com/SchibstedSpain/Barista/issues/100))
+- `writeToEditText()` method has been renamed to `writeTo()`. ([#140](https://github.com/SchibstedSpain/Barista/issues/140))
+- `writeToAutoCompleteTextView()` method has been renamed to `writeToAutoComplete()`. ([#140](https://github.com/SchibstedSpain/Barista/issues/140))
+- `clickCheckBoxItem()` methods have been deleted. Use `clickOn()` instead. ([#140](https://github.com/SchibstedSpain/Barista/issues/140))
+- `ListView` and `RecyclerView` actions have been merged into `ListActions` with these common methods ([#146](https://github.com/SchibstedSpain/Barista/issues/146)):
+  - `clickListItem(listId, position)`
+  - `scrollListToPosition(listId, position)`
+  - `clickListItemChild(listId, position, childId)`
+
+## New features
+- `ListView` and `RecyclerView` methods are the same. No need to use different method depending on the implementation. ([#146](https://github.com/SchibstedSpain/Barista/pull/146))
+- `ListView` or `RecyclerView` id is optional when only one instance of `ListView` or `RecyclerView` is displayed in the hierarchy. ([#146](https://github.com/SchibstedSpain/Barista/pull/146)
+- Drawer id on drawer actions and assertions is optional when only one DrawerLayout is present in the hierarchy. ([#161](https://github.com/SchibstedSpain/Barista/pull/161))
+- Drawer actions and assertions allow using non-default gravity with `openDrawerWithGravity()`, `closeDrawerWithGravity()`, `assertDrawerIsOpenWithGravity()` and `assertDrawerIsClosedWithGravity()`. ([#161](https://github.com/SchibstedSpain/Barista/pull/161))
+- `SwipeRefreshLayout` id is not optional in `refresh()` method when only one `SwipeRefreshLayout` is present in the hierarchy. ([#150](https://github.com/SchibstedSpain/Barista/pull/150))
+- Added `assertFocused()` and `assertNotFocused()` methods.
+([#157](https://github.com/SchibstedSpain/Barista/pull/157))
+- Added `assertDisplayed(id, text)` to check some text in a specific view. ([#150](https://github.com/SchibstedSpain/Barista/pull/150))
+- Added `FlakyTestRule` which enables the functionalities from `FlakyActivityTestRule` without forcing the inheritance dependency. ([#160](https://github.com/SchibstedSpain/Barista/pull/160))
+
+## Behaviour changes
+
+#### Error handling
+- Espresso's FailureHandler is not invoked anymore while Barista attempts to do its magic. It will only receive errors that actually make your test fail. This means you can use a custom FailureHandler for things like taking screenshots upon failures. ([#134](https://github.com/SchibstedSpain/Barista/pull/134))
+- We also improved some error messages when things go wrong, so you don't need to decipher what they mean. If you find any message that doesn't make much sense, open en issue!

--- a/MIGRATION-2.0.md
+++ b/MIGRATION-2.0.md
@@ -22,12 +22,12 @@ com.schibsted.spain.barista.rule
 - `clickCheckBoxItem()` methods have been deleted. Use `clickOn()` instead. ([#140](https://github.com/SchibstedSpain/Barista/issues/140))
 - `ListView` and `RecyclerView` actions have been merged into `ListActions` with these common methods ([#146](https://github.com/SchibstedSpain/Barista/issues/146)):
   - `clickListItem(listId, position)`
-  - `scrollListToPosition(listId, position)`
   - `clickListItemChild(listId, position, childId)`
+  - `scrollListToPosition(listId, position)`
 
 ## New features
 - `ListView` and `RecyclerView` methods are the same. No need to use different method depending on the implementation. ([#146](https://github.com/SchibstedSpain/Barista/pull/146))
-- `ListView` or `RecyclerView` id is optional when only one instance of `ListView` or `RecyclerView` is displayed in the hierarchy. ([#146](https://github.com/SchibstedSpain/Barista/pull/146)
+- `ListView` or `RecyclerView` id is optional when only one instance of `ListView` or `RecyclerView` is displayed in the hierarchy. ([#146](https://github.com/SchibstedSpain/Barista/pull/146))
 - Drawer id on drawer actions and assertions is optional when only one DrawerLayout is present in the hierarchy. ([#161](https://github.com/SchibstedSpain/Barista/pull/161))
 - Drawer actions and assertions allow using non-default gravity with `openDrawerWithGravity()`, `closeDrawerWithGravity()`, `assertDrawerIsOpenWithGravity()` and `assertDrawerIsClosedWithGravity()`. ([#161](https://github.com/SchibstedSpain/Barista/pull/161))
 - `SwipeRefreshLayout` id is now optional in `refresh()` method when only one `SwipeRefreshLayout` is present in the hierarchy. ([#150](https://github.com/SchibstedSpain/Barista/pull/150))
@@ -40,4 +40,4 @@ com.schibsted.spain.barista.rule
 
 #### Error handling
 - Espresso's FailureHandler is not invoked anymore while Barista attempts to do its magic. It will only receive errors that actually make your test fail. This means you can use a custom FailureHandler for things like taking screenshots upon failures. ([#134](https://github.com/SchibstedSpain/Barista/pull/134))
-- We also improved some error messages when things go wrong, so you don't need to decipher what they mean. If you find any message that doesn't make much sense, open en issue!
+- We also improved some error messages when things go wrong, so you don't need to decipher what they mean. If you find any message that doesn't make much sense, open an issue!

--- a/MIGRATION-2.0.md
+++ b/MIGRATION-2.0.md
@@ -20,7 +20,7 @@ com.schibsted.spain.barista.rule
 - `writeToEditText()` method has been renamed to `writeTo()`. ([#140](https://github.com/SchibstedSpain/Barista/issues/140))
 - `writeToAutoCompleteTextView()` method has been renamed to `writeToAutoComplete()`. ([#140](https://github.com/SchibstedSpain/Barista/issues/140))
 - `clickCheckBoxItem()` methods have been deleted. Use `clickOn()` instead. ([#140](https://github.com/SchibstedSpain/Barista/issues/140))
-- `ListView` and `RecyclerView` actions have been merged into `ListActions` with these common methods ([#146](https://github.com/SchibstedSpain/Barista/issues/146)):
+- `ListView` and `RecyclerView` actions have been merged into `ListInteractions` with these common methods ([#146](https://github.com/SchibstedSpain/Barista/issues/146)):
   - `clickListItem(listId, position)`
   - `clickListItemChild(listId, position, childId)`
   - `scrollListToPosition(listId, position)`
@@ -28,8 +28,8 @@ com.schibsted.spain.barista.rule
 ## New features
 - `ListView` and `RecyclerView` methods are the same. No need to use different method depending on the implementation. ([#146](https://github.com/SchibstedSpain/Barista/pull/146))
 - `ListView` or `RecyclerView` id is optional when only one instance of `ListView` or `RecyclerView` is displayed in the hierarchy. ([#146](https://github.com/SchibstedSpain/Barista/pull/146))
-- Drawer id on drawer actions and assertions is optional when only one DrawerLayout is present in the hierarchy. ([#161](https://github.com/SchibstedSpain/Barista/pull/161))
-- Drawer actions and assertions allow using non-default gravity with `openDrawerWithGravity()`, `closeDrawerWithGravity()`, `assertDrawerIsOpenWithGravity()` and `assertDrawerIsClosedWithGravity()`. ([#161](https://github.com/SchibstedSpain/Barista/pull/161))
+- Drawer id on drawer interactions and assertions is optional when only one DrawerLayout is present in the hierarchy. ([#161](https://github.com/SchibstedSpain/Barista/pull/161))
+- Drawer interactions and assertions allow using non-default gravity with `openDrawerWithGravity()`, `closeDrawerWithGravity()`, `assertDrawerIsOpenWithGravity()` and `assertDrawerIsClosedWithGravity()`. ([#161](https://github.com/SchibstedSpain/Barista/pull/161))
 - `SwipeRefreshLayout` id is now optional in `refresh()` method when only one `SwipeRefreshLayout` is present in the hierarchy. ([#150](https://github.com/SchibstedSpain/Barista/pull/150))
 - Added `assertFocused()` and `assertNotFocused()` methods.
 ([#157](https://github.com/SchibstedSpain/Barista/pull/157))

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Barista makes developing UI test faster, easier and more predictable. Built on t
 
 # Download
 
-_Pss, hey. Migrating to Barista 2.0? [Check out this guide](MIGRATION-2.0.md) to help you with the transition._
+_Psst, hey. Migrating to Barista 2.0? [Check out this guide](MIGRATION-2.0.md) to help you with the transition._
 
 Import Barista as a testing dependency:
 ```gradle

--- a/README.md
+++ b/README.md
@@ -55,9 +55,8 @@ writeToAutoComplete(R.id.autocomplete, "Another great text");
 
 // Operate on ListViews and RecyclerViews indistinctly by position
 clickListItem(R.id.list, 4);
-scrollListToPosition(R.id.list, 4);
 clickListItemChild(R.id.list, 3, R.id.row_button);
-clickListItemChild(R.id.list, 3, "Button");
+scrollListToPosition(R.id.list, 4);
 
 clickSpinnerItem(R.id.spinner, 1);
 
@@ -82,8 +81,8 @@ swipeViewPagerBack();
 
 // Interact with the navigation drawer
 openDrawer();
-closeDrawer();
 openDrawerWithGravity(Gravity.RIGHT);
+closeDrawer();
 closeDrawerWithGravity(Gravity.RIGHT);
 
 // Pull to refresh in SwipeRefreshLayout
@@ -101,14 +100,14 @@ sleep(2, SECONDS);
 assertDisplayed("Hello world");
 assertDisplayed(R.string.hello_world);
 assertDisplayed(R.id.button);
+assertDisplayed(R.id.button, "Hello world")
 
 // ...or not?
 assertNotDisplayed("Hello world");
 assertNotDisplayed(R.string.hello_world);
 assertNotDisplayed(R.id.button);
+assertNotDisplayed(R.id.button, "Hello world")
 
-// Is this text displayed in this exact view?
-assertDisplayed(R.id.view, "Hello world")
 
 // Is this view enabled?
 assertEnabled("Hello world");
@@ -140,13 +139,13 @@ assertFocused(R.id.focused_view)
 assertFocused("Button")
 
 // ... or not?
-assertFocused(R.id.focused_view)
-assertFocused("Button")
+assertNotFocused(R.id.focused_view)
+assertNotFocused("Button")
 
 // What's the state of the Drawer?
 assertDrawerIsOpen();
-assertDrawerIsClosed();
 assertDrawerIsOpenWithGravity(Gravity.RIGHT);
+assertDrawerIsClosed();
 assertDrawerIsClosedWithGravity(Gravity.RIGHT);
 
 // Check EditText's hints
@@ -172,7 +171,7 @@ PermissionGranter.allowPermissionsIfNeeded(Manifest.permission.GET_ACCOUNTS);
 ```
 
 ## Useful test rules
-Barista includes a set of useful rules test rules to help your tests.
+Barista includes a set of useful test rules to help you:
 
 ### Reseting app data
 

--- a/README.md
+++ b/README.md
@@ -195,9 +195,14 @@ As tests should be isolated, they need to set the environment before running. Es
 We should try to write deterministic tests, but when everything else fails Barista helps you deal with flaky tests using a specific ActivityTestRule and a couple of annotations that repeat your tests multiple times.
 
 ```java
-// Use this rule instead of Espresso's ActivityTestRule
+// Use a RuleChain to wrap your ActivityTestRule with a FlakyTestRule
+private ActivityTestRule<FlakyActivity> activityRule = new ActivityTestRule<>(FlakyActivity.class);
+private FlakyTestRule flakyRule = new FlakyTestRule();
+
 @Rule
-public FlakyActivityTestRule<FlakyActivity> activityRule = new FlakyActivityTestRule<>(FlakyActivity.class, true, false);
+public RuleChain chain = RuleChain.outerRule(flakyRule)
+    .around(activityRule);
+
 
 // Use @AllowFlaky to let flaky tests pass if they pass any time.
 @Test


### PR DESCRIPTION
We're almost there! I updated the readme with the recent changes and wrote a migration guide for 2.0 with detailed breaking changes from 1.x.

In the readme, I've put the download section at the top to make it easier to copy&paste.

I did it incrementally, so I might have missed something. Please take a look:
- [Migration guide](https://github.com/SchibstedSpain/Barista/blob/readme2/MIGRATION-2.0.md)
- [New readme](https://github.com/SchibstedSpain/Barista/blob/readme2/README.md)
