### PR TITLE
Split assertion classes

### DIFF
--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaAssertions.kt
@@ -19,26 +19,6 @@ import org.junit.Assert.fail
 object BaristaAssertions {
 
     @JvmStatic
-    fun assertChecked(resId: Int) {
-        onView(resId.resourceMatcher()).check(matches(isChecked()))
-    }
-
-    @JvmStatic
-    fun assertChecked(text: String) {
-        onView(withText(text)).check(matches(isChecked()))
-    }
-
-    @JvmStatic
-    fun assertUnchecked(resId: Int) {
-        onView(resId.resourceMatcher()).check(matches(isNotChecked()))
-    }
-
-    @JvmStatic
-    fun assertUnchecked(text: String) {
-        onView(withText(text)).check(matches(isNotChecked()))
-    }
-
-    @JvmStatic
     fun assertThatBackButtonClosesTheApp() {
         // Will launch an Exception if it closes the app
         try {

--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaAssertions.kt
@@ -9,9 +9,7 @@ import android.support.test.espresso.assertion.ViewAssertions.matches
 import android.support.test.espresso.matcher.ViewMatchers.isRoot
 import android.support.test.espresso.matcher.ViewMatchers.withId
 import com.schibsted.spain.barista.internal.failurehandler.RethrowingFailureHandler
-import com.schibsted.spain.barista.internal.matcher.DisplayedMatchers.displayedWithId
 import com.schibsted.spain.barista.internal.matcher.DrawableMatchers.withDrawable
-import com.schibsted.spain.barista.internal.matcher.RecyclerViewItemCountAssertion
 import org.junit.Assert.fail
 
 object BaristaAssertions {
@@ -30,11 +28,6 @@ object BaristaAssertions {
         }
     }
 
-    @JvmStatic
-    fun assertRecyclerViewItemCount(@IdRes recyclerViewId: Int, expectedItemCount: Int) {
-        onView(displayedWithId(recyclerViewId)).check(
-                RecyclerViewItemCountAssertion(expectedItemCount))
-    }
 
     @JvmStatic
     fun assertDrawable(@IdRes id: Int, @DrawableRes drawable: Int) {

--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaAssertions.kt
@@ -2,12 +2,12 @@ package com.schibsted.spain.barista.assertion
 
 import android.support.annotation.DrawableRes
 import android.support.annotation.IdRes
-import android.support.annotation.StringRes
 import android.support.test.espresso.Espresso.onView
 import android.support.test.espresso.NoActivityResumedException
 import android.support.test.espresso.action.ViewActions
 import android.support.test.espresso.assertion.ViewAssertions.matches
-import android.support.test.espresso.matcher.ViewMatchers.*
+import android.support.test.espresso.matcher.ViewMatchers.isRoot
+import android.support.test.espresso.matcher.ViewMatchers.withId
 import com.schibsted.spain.barista.internal.failurehandler.RethrowingFailureHandler
 import com.schibsted.spain.barista.internal.matcher.DisplayedMatchers.displayedWithId
 import com.schibsted.spain.barista.internal.matcher.DrawableMatchers.withDrawable
@@ -34,16 +34,6 @@ object BaristaAssertions {
     fun assertRecyclerViewItemCount(@IdRes recyclerViewId: Int, expectedItemCount: Int) {
         onView(displayedWithId(recyclerViewId)).check(
                 RecyclerViewItemCountAssertion(expectedItemCount))
-    }
-
-    @JvmStatic
-    fun assertHint(@IdRes id: Int, @StringRes text: Int) {
-        onView(withId(id)).check(matches(withHint(text)))
-    }
-
-    @JvmStatic
-    fun assertHint(@IdRes id: Int, text: String) {
-        onView(withId(id)).check(matches(withHint(text)))
     }
 
     @JvmStatic

--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaAssertions.kt
@@ -3,81 +3,20 @@ package com.schibsted.spain.barista.assertion
 import android.support.annotation.DrawableRes
 import android.support.annotation.IdRes
 import android.support.annotation.StringRes
-import android.support.test.espresso.AmbiguousViewMatcherException
 import android.support.test.espresso.Espresso.onView
 import android.support.test.espresso.NoActivityResumedException
-import android.support.test.espresso.NoMatchingViewException
 import android.support.test.espresso.action.ViewActions
-import android.support.test.espresso.assertion.ViewAssertions.doesNotExist
 import android.support.test.espresso.assertion.ViewAssertions.matches
 import android.support.test.espresso.matcher.ViewMatchers.*
-import android.view.View
 import com.schibsted.spain.barista.internal.failurehandler.RethrowingFailureHandler
-import com.schibsted.spain.barista.internal.failurehandler.SpyFailureHandler
-import com.schibsted.spain.barista.internal.failurehandler.description
 import com.schibsted.spain.barista.internal.matcher.DisplayedMatchers.displayedWithId
 import com.schibsted.spain.barista.internal.matcher.DrawableMatchers.withDrawable
-import com.schibsted.spain.barista.internal.matcher.HelperMatchers.firstViewOf
 import com.schibsted.spain.barista.internal.matcher.RecyclerViewItemCountAssertion
 import com.schibsted.spain.barista.internal.util.resourceMatcher
-import org.hamcrest.Matcher
-import org.hamcrest.Matchers.allOf
 import org.hamcrest.core.IsNot.not
 import org.junit.Assert.fail
 
 object BaristaAssertions {
-
-    @JvmStatic
-    fun assertDisplayed(resId: Int) {
-        assertDisplayed(resId.resourceMatcher())
-    }
-
-    @JvmStatic
-    fun assertDisplayed(text: String) {
-        assertDisplayed(withText(text))
-    }
-
-    @JvmStatic
-    fun assertDisplayed(@IdRes resId: Int, text: String) {
-        onView(withId(resId)).check(matches(withText(text)))
-    }
-
-    private fun assertDisplayed(matcher: Matcher<View>) {
-        val spyFailureHandler = SpyFailureHandler()
-        try {
-            onView(matcher)
-                    .withFailureHandler(spyFailureHandler)
-                    .check(matches(isDisplayed()))
-        } catch (multipleViews: AmbiguousViewMatcherException) {
-            try {
-                onView(firstViewOf(allOf(matcher, isDisplayed())))
-                        .withFailureHandler(spyFailureHandler)
-                        .check(matches(isDisplayed()))
-            } catch (notDisplayedError: NoMatchingViewException) {
-                spyFailureHandler.resendFirstError("View ${matcher.description()} wasn't displayed on the screen")
-            }
-        }
-    }
-
-    @JvmStatic
-    fun assertNotExist(resId: Int) {
-        onView(resId.resourceMatcher()).check(doesNotExist())
-    }
-
-    @JvmStatic
-    fun assertNotExist(text: String) {
-        onView(withText(text)).check(doesNotExist())
-    }
-
-    @JvmStatic
-    fun assertNotDisplayed(resId: Int) {
-        onView(resId.resourceMatcher()).check(matches(not(isDisplayed())))
-    }
-
-    @JvmStatic
-    fun assertNotDisplayed(text: String) {
-        onView(withText(text)).check(matches(not(isDisplayed())))
-    }
 
     @JvmStatic
     fun assertEnabled(resId: Int) {

--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaAssertions.kt
@@ -1,15 +1,10 @@
 package com.schibsted.spain.barista.assertion
 
-import android.support.annotation.DrawableRes
-import android.support.annotation.IdRes
 import android.support.test.espresso.Espresso.onView
 import android.support.test.espresso.NoActivityResumedException
 import android.support.test.espresso.action.ViewActions
-import android.support.test.espresso.assertion.ViewAssertions.matches
 import android.support.test.espresso.matcher.ViewMatchers.isRoot
-import android.support.test.espresso.matcher.ViewMatchers.withId
 import com.schibsted.spain.barista.internal.failurehandler.RethrowingFailureHandler
-import com.schibsted.spain.barista.internal.matcher.DrawableMatchers.withDrawable
 import org.junit.Assert.fail
 
 object BaristaAssertions {
@@ -28,9 +23,4 @@ object BaristaAssertions {
         }
     }
 
-
-    @JvmStatic
-    fun assertDrawable(@IdRes id: Int, @DrawableRes drawable: Int) {
-        onView(withId(id)).check(matches(withDrawable(drawable)))
-    }
 }

--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaAssertions.kt
@@ -12,8 +12,6 @@ import com.schibsted.spain.barista.internal.failurehandler.RethrowingFailureHand
 import com.schibsted.spain.barista.internal.matcher.DisplayedMatchers.displayedWithId
 import com.schibsted.spain.barista.internal.matcher.DrawableMatchers.withDrawable
 import com.schibsted.spain.barista.internal.matcher.RecyclerViewItemCountAssertion
-import com.schibsted.spain.barista.internal.util.resourceMatcher
-import org.hamcrest.core.IsNot.not
 import org.junit.Assert.fail
 
 object BaristaAssertions {
@@ -51,25 +49,5 @@ object BaristaAssertions {
     @JvmStatic
     fun assertDrawable(@IdRes id: Int, @DrawableRes drawable: Int) {
         onView(withId(id)).check(matches(withDrawable(drawable)))
-    }
-
-    @JvmStatic
-    fun assertFocused(@IdRes resId: Int) {
-        onView(resId.resourceMatcher()).check(matches(hasFocus()))
-    }
-
-    @JvmStatic
-    fun assertNotFocused(@IdRes resId: Int) {
-        onView(resId.resourceMatcher()).check(matches(not(hasFocus())))
-    }
-
-    @JvmStatic
-    fun assertFocused(text: String) {
-        onView(withText(text)).check(matches(hasFocus()))
-    }
-
-    @JvmStatic
-    fun assertNotFocused(text: String) {
-        onView(withText(text)).check(matches(not(hasFocus())))
     }
 }

--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaAssertions.kt
@@ -19,26 +19,6 @@ import org.junit.Assert.fail
 object BaristaAssertions {
 
     @JvmStatic
-    fun assertEnabled(resId: Int) {
-        onView(resId.resourceMatcher()).check(matches(isEnabled()))
-    }
-
-    @JvmStatic
-    fun assertEnabled(text: String) {
-        onView(withText(text)).check(matches(isEnabled()))
-    }
-
-    @JvmStatic
-    fun assertDisabled(resId: Int) {
-        onView(resId.resourceMatcher()).check(matches(not(isEnabled())))
-    }
-
-    @JvmStatic
-    fun assertDisabled(text: String) {
-        onView(withText(text)).check(matches(not(isEnabled())))
-    }
-
-    @JvmStatic
     fun assertChecked(resId: Int) {
         onView(resId.resourceMatcher()).check(matches(isChecked()))
     }

--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaCheckedAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaCheckedAssertions.kt
@@ -1,0 +1,29 @@
+package com.schibsted.spain.barista.assertion
+
+import android.support.test.espresso.Espresso.onView
+import android.support.test.espresso.assertion.ViewAssertions.matches
+import android.support.test.espresso.matcher.ViewMatchers.*
+import com.schibsted.spain.barista.internal.util.resourceMatcher
+
+object BaristaCheckedAssertions {
+
+    @JvmStatic
+    fun assertChecked(resId: Int) {
+        onView(resId.resourceMatcher()).check(matches(isChecked()))
+    }
+
+    @JvmStatic
+    fun assertChecked(text: String) {
+        onView(withText(text)).check(matches(isChecked()))
+    }
+
+    @JvmStatic
+    fun assertUnchecked(resId: Int) {
+        onView(resId.resourceMatcher()).check(matches(isNotChecked()))
+    }
+
+    @JvmStatic
+    fun assertUnchecked(text: String) {
+        onView(withText(text)).check(matches(isNotChecked()))
+    }
+}

--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaEnabledAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaEnabledAssertions.kt
@@ -1,0 +1,31 @@
+package com.schibsted.spain.barista.assertion
+
+import android.support.test.espresso.Espresso.onView
+import android.support.test.espresso.assertion.ViewAssertions.matches
+import android.support.test.espresso.matcher.ViewMatchers.isEnabled
+import android.support.test.espresso.matcher.ViewMatchers.withText
+import com.schibsted.spain.barista.internal.util.resourceMatcher
+import org.hamcrest.core.IsNot.not
+
+object BaristaEnabledAssertions {
+
+    @JvmStatic
+    fun assertEnabled(resId: Int) {
+        onView(resId.resourceMatcher()).check(matches(isEnabled()))
+    }
+
+    @JvmStatic
+    fun assertEnabled(text: String) {
+        onView(withText(text)).check(matches(isEnabled()))
+    }
+
+    @JvmStatic
+    fun assertDisabled(resId: Int) {
+        onView(resId.resourceMatcher()).check(matches(not(isEnabled())))
+    }
+
+    @JvmStatic
+    fun assertDisabled(text: String) {
+        onView(withText(text)).check(matches(not(isEnabled())))
+    }
+}

--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaFocusAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaFocusAssertions.kt
@@ -1,0 +1,32 @@
+package com.schibsted.spain.barista.assertion
+
+import android.support.annotation.IdRes
+import android.support.test.espresso.Espresso.onView
+import android.support.test.espresso.assertion.ViewAssertions.matches
+import android.support.test.espresso.matcher.ViewMatchers.hasFocus
+import android.support.test.espresso.matcher.ViewMatchers.withText
+import com.schibsted.spain.barista.internal.util.resourceMatcher
+import org.hamcrest.core.IsNot.not
+
+object BaristaFocusAssertions {
+
+    @JvmStatic
+    fun assertFocused(@IdRes resId: Int) {
+        onView(resId.resourceMatcher()).check(matches(hasFocus()))
+    }
+
+    @JvmStatic
+    fun assertNotFocused(@IdRes resId: Int) {
+        onView(resId.resourceMatcher()).check(matches(not(hasFocus())))
+    }
+
+    @JvmStatic
+    fun assertFocused(text: String) {
+        onView(withText(text)).check(matches(hasFocus()))
+    }
+
+    @JvmStatic
+    fun assertNotFocused(text: String) {
+        onView(withText(text)).check(matches(not(hasFocus())))
+    }
+}

--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaFocusedAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaFocusedAssertions.kt
@@ -8,7 +8,7 @@ import android.support.test.espresso.matcher.ViewMatchers.withText
 import com.schibsted.spain.barista.internal.util.resourceMatcher
 import org.hamcrest.core.IsNot.not
 
-object BaristaFocusAssertions {
+object BaristaFocusedAssertions {
 
     @JvmStatic
     fun assertFocused(@IdRes resId: Int) {

--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaHintAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaHintAssertions.kt
@@ -1,0 +1,22 @@
+package com.schibsted.spain.barista.assertion
+
+import android.support.annotation.IdRes
+import android.support.annotation.StringRes
+import android.support.test.espresso.Espresso.onView
+import android.support.test.espresso.assertion.ViewAssertions.matches
+import android.support.test.espresso.matcher.ViewMatchers.withHint
+import android.support.test.espresso.matcher.ViewMatchers.withId
+
+object BaristaHintAssertions {
+
+    @JvmStatic
+    fun assertHint(@IdRes id: Int, @StringRes text: Int) {
+        onView(withId(id)).check(matches(withHint(text)))
+    }
+
+    @JvmStatic
+    fun assertHint(@IdRes id: Int, text: String) {
+        onView(withId(id)).check(matches(withHint(text)))
+    }
+
+}

--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaImageViewAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaImageViewAssertions.kt
@@ -1,0 +1,17 @@
+package com.schibsted.spain.barista.assertion
+
+import android.support.annotation.DrawableRes
+import android.support.annotation.IdRes
+import android.support.test.espresso.Espresso
+import android.support.test.espresso.assertion.ViewAssertions
+import android.support.test.espresso.matcher.ViewMatchers
+import com.schibsted.spain.barista.internal.matcher.DrawableMatchers
+
+object BaristaImageViewAssertions {
+
+    @JvmStatic
+    fun assertDrawable(@IdRes id: Int, @DrawableRes drawable: Int) {
+        Espresso.onView(ViewMatchers.withId(id)).check(ViewAssertions.matches(DrawableMatchers.withDrawable(drawable)))
+    }
+
+}

--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaRecyclerViewAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaRecyclerViewAssertions.kt
@@ -1,0 +1,15 @@
+package com.schibsted.spain.barista.assertion
+
+import android.support.annotation.IdRes
+import android.support.test.espresso.Espresso.onView
+import com.schibsted.spain.barista.internal.matcher.DisplayedMatchers.displayedWithId
+import com.schibsted.spain.barista.internal.matcher.RecyclerViewItemCountAssertion
+
+object BaristaRecyclerViewAssertions {
+
+    @JvmStatic
+    fun assertRecyclerViewItemCount(@IdRes recyclerViewId: Int, expectedItemCount: Int) {
+        onView(displayedWithId(recyclerViewId)).check(RecyclerViewItemCountAssertion(expectedItemCount))
+    }
+
+}

--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaVisibilityAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaVisibilityAssertions.kt
@@ -1,0 +1,73 @@
+package com.schibsted.spain.barista.assertion
+
+import android.support.annotation.IdRes
+import android.support.test.espresso.AmbiguousViewMatcherException
+import android.support.test.espresso.Espresso.onView
+import android.support.test.espresso.NoMatchingViewException
+import android.support.test.espresso.assertion.ViewAssertions.doesNotExist
+import android.support.test.espresso.assertion.ViewAssertions.matches
+import android.support.test.espresso.matcher.ViewMatchers.*
+import android.view.View
+import com.schibsted.spain.barista.internal.failurehandler.SpyFailureHandler
+import com.schibsted.spain.barista.internal.failurehandler.description
+import com.schibsted.spain.barista.internal.matcher.HelperMatchers
+import com.schibsted.spain.barista.internal.util.resourceMatcher
+import org.hamcrest.Matcher
+import org.hamcrest.Matchers.allOf
+import org.hamcrest.core.IsNot.not
+
+object BaristaVisibilityAssertions{
+
+    @JvmStatic
+    fun assertDisplayed(resId: Int) {
+        assertDisplayed(resId.resourceMatcher())
+    }
+
+    @JvmStatic
+    fun assertDisplayed(text: String) {
+        assertDisplayed(withText(text))
+    }
+
+    @JvmStatic
+    fun assertDisplayed(@IdRes resId: Int, text: String) {
+        onView(withId(resId)).check(matches(withText(text)))
+    }
+
+    private fun assertDisplayed(matcher: Matcher<View>) {
+        val spyFailureHandler = SpyFailureHandler()
+        try {
+            onView(matcher)
+                    .withFailureHandler(spyFailureHandler)
+                    .check(matches(isDisplayed()))
+        } catch (multipleViews: AmbiguousViewMatcherException) {
+            try {
+                onView(HelperMatchers.firstViewOf(allOf(matcher, isDisplayed())))
+                        .withFailureHandler(spyFailureHandler)
+                        .check(matches(isDisplayed()))
+            } catch (notDisplayedError: NoMatchingViewException) {
+                spyFailureHandler.resendFirstError("View ${matcher.description()} wasn't displayed on the screen")
+            }
+        }
+    }
+
+    @JvmStatic
+    fun assertNotExist(resId: Int) {
+        onView(resId.resourceMatcher()).check(doesNotExist())
+    }
+
+    @JvmStatic
+    fun assertNotExist(text: String) {
+        onView(withText(text)).check(doesNotExist())
+    }
+
+    @JvmStatic
+    fun assertNotDisplayed(resId: Int) {
+        onView(resId.resourceMatcher()).check(matches(not(isDisplayed())))
+    }
+
+    @JvmStatic
+    fun assertNotDisplayed(text: String) {
+        onView(withText(text)).check(matches(not(isDisplayed())))
+    }
+
+}

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertionsTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertionsTest.java
@@ -13,8 +13,8 @@ import static com.schibsted.spain.barista.assertion.BaristaCheckedAssertions.ass
 import static com.schibsted.spain.barista.assertion.BaristaCheckedAssertions.assertUnchecked;
 import static com.schibsted.spain.barista.assertion.BaristaEnabledAssertions.assertDisabled;
 import static com.schibsted.spain.barista.assertion.BaristaEnabledAssertions.assertEnabled;
-import static com.schibsted.spain.barista.assertion.BaristaFocusAssertions.assertFocused;
-import static com.schibsted.spain.barista.assertion.BaristaFocusAssertions.assertNotFocused;
+import static com.schibsted.spain.barista.assertion.BaristaFocusedAssertions.assertFocused;
+import static com.schibsted.spain.barista.assertion.BaristaFocusedAssertions.assertNotFocused;
 import static com.schibsted.spain.barista.assertion.BaristaImageViewAssertions.assertDrawable;
 import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertDisplayed;
 import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertNotDisplayed;

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertionsTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertionsTest.java
@@ -8,12 +8,12 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertChecked;
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertDrawable;
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertFocused;
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertNotFocused;
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertThatBackButtonClosesTheApp;
-import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertUnchecked;
+import static com.schibsted.spain.barista.assertion.BaristaCheckedAssertions.assertChecked;
+import static com.schibsted.spain.barista.assertion.BaristaCheckedAssertions.assertUnchecked;
 import static com.schibsted.spain.barista.assertion.BaristaEnabledAssertions.assertDisabled;
 import static com.schibsted.spain.barista.assertion.BaristaEnabledAssertions.assertEnabled;
 import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertDisplayed;

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertionsTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertionsTest.java
@@ -9,13 +9,13 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertDrawable;
-import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertFocused;
-import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertNotFocused;
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertThatBackButtonClosesTheApp;
 import static com.schibsted.spain.barista.assertion.BaristaCheckedAssertions.assertChecked;
 import static com.schibsted.spain.barista.assertion.BaristaCheckedAssertions.assertUnchecked;
 import static com.schibsted.spain.barista.assertion.BaristaEnabledAssertions.assertDisabled;
 import static com.schibsted.spain.barista.assertion.BaristaEnabledAssertions.assertEnabled;
+import static com.schibsted.spain.barista.assertion.BaristaFocusAssertions.assertFocused;
+import static com.schibsted.spain.barista.assertion.BaristaFocusAssertions.assertNotFocused;
 import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertDisplayed;
 import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertNotDisplayed;
 import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertNotExist;

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertionsTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertionsTest.java
@@ -8,7 +8,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertDrawable;
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertThatBackButtonClosesTheApp;
 import static com.schibsted.spain.barista.assertion.BaristaCheckedAssertions.assertChecked;
 import static com.schibsted.spain.barista.assertion.BaristaCheckedAssertions.assertUnchecked;
@@ -16,6 +15,7 @@ import static com.schibsted.spain.barista.assertion.BaristaEnabledAssertions.ass
 import static com.schibsted.spain.barista.assertion.BaristaEnabledAssertions.assertEnabled;
 import static com.schibsted.spain.barista.assertion.BaristaFocusAssertions.assertFocused;
 import static com.schibsted.spain.barista.assertion.BaristaFocusAssertions.assertNotFocused;
+import static com.schibsted.spain.barista.assertion.BaristaImageViewAssertions.assertDrawable;
 import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertDisplayed;
 import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertNotDisplayed;
 import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertNotExist;

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertionsTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertionsTest.java
@@ -10,15 +10,15 @@ import org.junit.runner.RunWith;
 
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertChecked;
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertDisabled;
-import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertDisplayed;
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertDrawable;
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertEnabled;
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertFocused;
-import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertNotDisplayed;
-import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertNotExist;
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertNotFocused;
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertThatBackButtonClosesTheApp;
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertUnchecked;
+import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertDisplayed;
+import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertNotDisplayed;
+import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertNotExist;
 import static junit.framework.Assert.fail;
 
 @RunWith(AndroidJUnit4.class)

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertionsTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertionsTest.java
@@ -9,13 +9,13 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertChecked;
-import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertDisabled;
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertDrawable;
-import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertEnabled;
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertFocused;
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertNotFocused;
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertThatBackButtonClosesTheApp;
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertUnchecked;
+import static com.schibsted.spain.barista.assertion.BaristaEnabledAssertions.assertDisabled;
+import static com.schibsted.spain.barista.assertion.BaristaEnabledAssertions.assertEnabled;
 import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertDisplayed;
 import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertNotDisplayed;
 import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertNotExist;

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AutoCompleteTextViewTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AutoCompleteTextViewTest.java
@@ -7,7 +7,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertDisplayed;
+import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertDisplayed;
 import static com.schibsted.spain.barista.interaction.BaristaAutoCompleteTextViewInteractions.writeToAutoComplete;
 
 @RunWith(AndroidJUnit4.class)

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/ClearDatabaseRuleTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/ClearDatabaseRuleTest.java
@@ -6,7 +6,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import static com.schibsted.spain.barista.interaction.BaristaClickInteractions.clickOn;
-import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertDisplayed;
+import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertDisplayed;
 
 public class ClearDatabaseRuleTest {
 

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/ClearFilesRuleTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/ClearFilesRuleTest.java
@@ -8,7 +8,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import static com.schibsted.spain.barista.interaction.BaristaClickInteractions.clickOn;
-import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertDisplayed;
+import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertDisplayed;
 
 public class ClearFilesRuleTest {
 

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/ClearPreferencesRuleTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/ClearPreferencesRuleTest.java
@@ -6,7 +6,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import static com.schibsted.spain.barista.interaction.BaristaClickInteractions.clickOn;
-import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertDisplayed;
+import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertDisplayed;
 
 public class ClearPreferencesRuleTest {
 

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/ClickInsideViewPagerTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/ClickInsideViewPagerTest.java
@@ -9,7 +9,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertDisplayed;
+import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertDisplayed;
 import static com.schibsted.spain.barista.interaction.BaristaClickInteractions.clickOn;
 
 @RunWith(AndroidJUnit4.class)

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/ClickTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/ClickTest.java
@@ -9,7 +9,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertDisplayed;
+import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertDisplayed;
 import static com.schibsted.spain.barista.interaction.BaristaClickInteractions.clickBack;
 import static com.schibsted.spain.barista.interaction.BaristaClickInteractions.clickOn;
 

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/DatePickerTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/DatePickerTest.java
@@ -9,7 +9,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertDisplayed;
+import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertDisplayed;
 import static com.schibsted.spain.barista.interaction.BaristaClickInteractions.clickOn;
 import static com.schibsted.spain.barista.interaction.BaristaPickerInteractions.setDateOnPicker;
 

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/DialogActivityTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/DialogActivityTest.java
@@ -10,7 +10,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertDisplayed;
+import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertDisplayed;
 import static com.schibsted.spain.barista.interaction.BaristaClickInteractions.clickOn;
 import static com.schibsted.spain.barista.interaction.BaristaDialogInteractions.clickDialogNegativeButton;
 import static com.schibsted.spain.barista.interaction.BaristaDialogInteractions.clickDialogNeutralButton;

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/DrawerActivityTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/DrawerActivityTest.java
@@ -12,8 +12,8 @@ import static com.schibsted.spain.barista.interaction.BaristaDrawerInteractions.
 import static com.schibsted.spain.barista.interaction.BaristaDrawerInteractions.closeDrawerWithGravity;
 import static com.schibsted.spain.barista.interaction.BaristaDrawerInteractions.openDrawer;
 import static com.schibsted.spain.barista.interaction.BaristaDrawerInteractions.openDrawerWithGravity;
-import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertDisplayed;
-import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertNotDisplayed;
+import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertDisplayed;
+import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertNotDisplayed;
 import static com.schibsted.spain.barista.assertion.BaristaDrawerAssertions.assertDrawerIsClosed;
 import static com.schibsted.spain.barista.assertion.BaristaDrawerAssertions.assertDrawerIsClosedWithGravity;
 import static com.schibsted.spain.barista.assertion.BaristaDrawerAssertions.assertDrawerIsOpen;

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/EditTextTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/EditTextTest.java
@@ -7,8 +7,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static com.schibsted.spain.barista.assertion.BaristaHintAssertions.assertHint;
 import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertDisplayed;
-import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertHint;
 import static com.schibsted.spain.barista.interaction.BaristaEditTextInteractions.writeTo;
 
 @RunWith(AndroidJUnit4.class)

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/EditTextTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/EditTextTest.java
@@ -7,7 +7,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertDisplayed;
+import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertDisplayed;
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertHint;
 import static com.schibsted.spain.barista.interaction.BaristaEditTextInteractions.writeTo;
 

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/ListsScrollTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/ListsScrollTest.java
@@ -9,8 +9,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static com.schibsted.spain.barista.interaction.BaristaListInteractions.scrollListToPosition;
-import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertDisplayed;
-import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertNotExist;
+import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertDisplayed;
+import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertNotExist;
 import static com.schibsted.spain.barista.sample.ListsActivity.FRUITS;
 import static com.schibsted.spain.barista.sample.ListsActivity.IntentBuilder;
 

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/LongClickTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/LongClickTest.java
@@ -7,7 +7,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertDisplayed;
+import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertDisplayed;
 import static com.schibsted.spain.barista.interaction.BaristaClickInteractions.longClickOn;
 
 @RunWith(AndroidJUnit4.class)

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/MenuClickTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/MenuClickTest.java
@@ -8,7 +8,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertDisplayed;
+import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertDisplayed;
 import static com.schibsted.spain.barista.interaction.BaristaMenuClickInteractions.clickMenu;
 
 @RunWith(AndroidJUnit4.class)

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/MenuSupportActionBarClickTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/MenuSupportActionBarClickTest.java
@@ -7,7 +7,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertDisplayed;
+import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertDisplayed;
 import static com.schibsted.spain.barista.interaction.BaristaMenuClickInteractions.clickMenu;
 
 @RunWith(AndroidJUnit4.class)

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/NestedScrollClickTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/NestedScrollClickTest.java
@@ -9,7 +9,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertDisplayed;
+import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertDisplayed;
 import static com.schibsted.spain.barista.interaction.BaristaClickInteractions.clickOn;
 
 @RunWith(AndroidJUnit4.class)

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/NestedScrollViewTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/NestedScrollViewTest.java
@@ -7,8 +7,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertDisplayed;
-import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertNotDisplayed;
+import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertDisplayed;
+import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertNotDisplayed;
 import static com.schibsted.spain.barista.interaction.BaristaScrollInteractions.scrollTo;
 
 @RunWith(AndroidJUnit4.class)

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/RadioButtonsReallyFarAwayTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/RadioButtonsReallyFarAwayTest.java
@@ -7,8 +7,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertDisplayed;
-import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertNotDisplayed;
+import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertDisplayed;
+import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertNotDisplayed;
 import static com.schibsted.spain.barista.interaction.BaristaRadioButtonInteractions.clickRadioButtonItem;
 import static com.schibsted.spain.barista.interaction.BaristaRadioButtonInteractions.clickRadioButtonPosition;
 

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/RadioButtonsTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/RadioButtonsTest.java
@@ -7,7 +7,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertDisplayed;
+import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertDisplayed;
 import static com.schibsted.spain.barista.interaction.BaristaRadioButtonInteractions.clickRadioButtonItem;
 import static com.schibsted.spain.barista.interaction.BaristaRadioButtonInteractions.clickRadioButtonPosition;
 

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/RecyclerViewInsideViewPagerTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/RecyclerViewInsideViewPagerTest.java
@@ -10,7 +10,7 @@ import org.junit.runner.RunWith;
 import static com.schibsted.spain.barista.interaction.BaristaListInteractions.clickListItem;
 import static com.schibsted.spain.barista.interaction.BaristaListInteractions.clickListItemChild;
 import static com.schibsted.spain.barista.interaction.BaristaListInteractions.scrollListToPosition;
-import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertDisplayed;
+import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertDisplayed;
 
 @RunWith(AndroidJUnit4.class)
 public class RecyclerViewInsideViewPagerTest {

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/ScrollsTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/ScrollsTest.java
@@ -2,14 +2,14 @@ package com.schibsted.spain.barista.sample;
 
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
-import com.schibsted.spain.barista.sample.util.FailureHandlerValidatorRule;
 import com.schibsted.spain.barista.internal.failurehandler.BaristaException;
+import com.schibsted.spain.barista.sample.util.FailureHandlerValidatorRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertDisplayed;
-import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertNotDisplayed;
+import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertDisplayed;
+import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertNotDisplayed;
 import static com.schibsted.spain.barista.interaction.BaristaScrollInteractions.safelyScrollTo;
 import static com.schibsted.spain.barista.interaction.BaristaScrollInteractions.scrollTo;
 

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/SpinnerTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/SpinnerTest.java
@@ -7,7 +7,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertDisplayed;
+import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertDisplayed;
 import static com.schibsted.spain.barista.interaction.BaristaSpinnerInteractions.clickSpinnerItem;
 
 @RunWith(AndroidJUnit4.class)

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/SwipeRefreshTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/SwipeRefreshTest.java
@@ -6,7 +6,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertDisplayed;
+import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertDisplayed;
 import static com.schibsted.spain.barista.interaction.BaristaSwipeRefreshInteractions.refresh;
 
 @RunWith(AndroidJUnit4.class)

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/ViewPagerTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/ViewPagerTest.java
@@ -8,7 +8,7 @@ import org.junit.runner.RunWith;
 
 import static com.schibsted.spain.barista.interaction.BaristaViewPagerInteractions.swipeViewPagerBack;
 import static com.schibsted.spain.barista.interaction.BaristaViewPagerInteractions.swipeViewPagerForward;
-import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertDisplayed;
+import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertDisplayed;
 
 @RunWith(AndroidJUnit4.class)
 public class ViewPagerTest {

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/ViewPagerWithoutIdTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/ViewPagerWithoutIdTest.java
@@ -8,7 +8,7 @@ import org.junit.runner.RunWith;
 
 import static com.schibsted.spain.barista.interaction.BaristaViewPagerInteractions.swipeViewPagerBack;
 import static com.schibsted.spain.barista.interaction.BaristaViewPagerInteractions.swipeViewPagerForward;
-import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertDisplayed;
+import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertDisplayed;
 
 @RunWith(AndroidJUnit4.class)
 public class ViewPagerWithoutIdTest {

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/WrappedViewClickTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/WrappedViewClickTest.java
@@ -8,7 +8,7 @@ import org.junit.Test;
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.action.ViewActions.click;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
-import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertDisplayed;
+import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertDisplayed;
 import static com.schibsted.spain.barista.internal.viewaction.PerformClickAction.clickUsingPerformClick;
 
 public class WrappedViewClickTest {

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/introduction/IntroducingBaristaAssertions.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/introduction/IntroducingBaristaAssertions.java
@@ -6,7 +6,6 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertDrawable;
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertThatBackButtonClosesTheApp;
 import static com.schibsted.spain.barista.assertion.BaristaCheckedAssertions.assertChecked;
 import static com.schibsted.spain.barista.assertion.BaristaCheckedAssertions.assertUnchecked;
@@ -15,6 +14,7 @@ import static com.schibsted.spain.barista.assertion.BaristaDrawerAssertions.asse
 import static com.schibsted.spain.barista.assertion.BaristaEnabledAssertions.assertDisabled;
 import static com.schibsted.spain.barista.assertion.BaristaEnabledAssertions.assertEnabled;
 import static com.schibsted.spain.barista.assertion.BaristaHintAssertions.assertHint;
+import static com.schibsted.spain.barista.assertion.BaristaImageViewAssertions.assertDrawable;
 import static com.schibsted.spain.barista.assertion.BaristaRecyclerViewAssertions.assertRecyclerViewItemCount;
 import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertDisplayed;
 import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertNotDisplayed;

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/introduction/IntroducingBaristaAssertions.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/introduction/IntroducingBaristaAssertions.java
@@ -7,7 +7,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertDrawable;
-import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertRecyclerViewItemCount;
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertThatBackButtonClosesTheApp;
 import static com.schibsted.spain.barista.assertion.BaristaCheckedAssertions.assertChecked;
 import static com.schibsted.spain.barista.assertion.BaristaCheckedAssertions.assertUnchecked;
@@ -16,6 +15,7 @@ import static com.schibsted.spain.barista.assertion.BaristaDrawerAssertions.asse
 import static com.schibsted.spain.barista.assertion.BaristaEnabledAssertions.assertDisabled;
 import static com.schibsted.spain.barista.assertion.BaristaEnabledAssertions.assertEnabled;
 import static com.schibsted.spain.barista.assertion.BaristaHintAssertions.assertHint;
+import static com.schibsted.spain.barista.assertion.BaristaRecyclerViewAssertions.assertRecyclerViewItemCount;
 import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertDisplayed;
 import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertNotDisplayed;
 import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertNotExist;

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/introduction/IntroducingBaristaAssertions.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/introduction/IntroducingBaristaAssertions.java
@@ -6,7 +6,8 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertChecked;
+import static com.schibsted.spain.barista.assertion.BaristaCheckedAssertions.assertChecked;
+import static com.schibsted.spain.barista.assertion.BaristaCheckedAssertions.assertUnchecked;
 import static com.schibsted.spain.barista.assertion.BaristaEnabledAssertions.assertDisabled;
 import static com.schibsted.spain.barista.assertion.BaristaEnabledAssertions.assertEnabled;
 import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertDisplayed;
@@ -16,7 +17,6 @@ import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.
 import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertNotExist;
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertRecyclerViewItemCount;
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertThatBackButtonClosesTheApp;
-import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertUnchecked;
 import static com.schibsted.spain.barista.assertion.BaristaDrawerAssertions.assertDrawerIsClosed;
 import static com.schibsted.spain.barista.assertion.BaristaDrawerAssertions.assertDrawerIsOpen;
 

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/introduction/IntroducingBaristaAssertions.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/introduction/IntroducingBaristaAssertions.java
@@ -7,10 +7,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertChecked;
-import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertDisabled;
+import static com.schibsted.spain.barista.assertion.BaristaEnabledAssertions.assertDisabled;
+import static com.schibsted.spain.barista.assertion.BaristaEnabledAssertions.assertEnabled;
 import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertDisplayed;
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertDrawable;
-import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertEnabled;
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertHint;
 import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertNotDisplayed;
 import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertNotExist;

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/introduction/IntroducingBaristaAssertions.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/introduction/IntroducingBaristaAssertions.java
@@ -8,12 +8,12 @@ import org.junit.runner.RunWith;
 
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertChecked;
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertDisabled;
-import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertDisplayed;
+import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertDisplayed;
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertDrawable;
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertEnabled;
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertHint;
-import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertNotDisplayed;
-import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertNotExist;
+import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertNotDisplayed;
+import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertNotExist;
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertRecyclerViewItemCount;
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertThatBackButtonClosesTheApp;
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertUnchecked;

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/introduction/IntroducingBaristaAssertions.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/introduction/IntroducingBaristaAssertions.java
@@ -6,19 +6,19 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static com.schibsted.spain.barista.assertion.BaristaCheckedAssertions.assertChecked;
-import static com.schibsted.spain.barista.assertion.BaristaCheckedAssertions.assertUnchecked;
-import static com.schibsted.spain.barista.assertion.BaristaEnabledAssertions.assertDisabled;
-import static com.schibsted.spain.barista.assertion.BaristaEnabledAssertions.assertEnabled;
-import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertDisplayed;
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertDrawable;
-import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertHint;
-import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertNotDisplayed;
-import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertNotExist;
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertRecyclerViewItemCount;
 import static com.schibsted.spain.barista.assertion.BaristaAssertions.assertThatBackButtonClosesTheApp;
+import static com.schibsted.spain.barista.assertion.BaristaCheckedAssertions.assertChecked;
+import static com.schibsted.spain.barista.assertion.BaristaCheckedAssertions.assertUnchecked;
 import static com.schibsted.spain.barista.assertion.BaristaDrawerAssertions.assertDrawerIsClosed;
 import static com.schibsted.spain.barista.assertion.BaristaDrawerAssertions.assertDrawerIsOpen;
+import static com.schibsted.spain.barista.assertion.BaristaEnabledAssertions.assertDisabled;
+import static com.schibsted.spain.barista.assertion.BaristaEnabledAssertions.assertEnabled;
+import static com.schibsted.spain.barista.assertion.BaristaHintAssertions.assertHint;
+import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertDisplayed;
+import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertNotDisplayed;
+import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertNotExist;
 
 @RunWith(AndroidJUnit4.class)
 public class IntroducingBaristaAssertions {


### PR DESCRIPTION
#The assertions class is growing with lots of unrelated methods.

Since we're breaking the API with 2.0, it's the best time to split them into topic-related classes, just like we do with Interaction methods.

These are the new classes:
![screen shot 2017-11-21 at 16 26 03](https://user-images.githubusercontent.com/545251/33080565-bb75d45a-ced8-11e7-9695-de34d31ecffb.png)
Some are named after the the concept they assert, some after the only View type they support. Just like the Interactions.