### PR TITLE
Add keyboard actions to BaristaEditTextInteractions and BaristaAutoCompleteTextViewInteractions

### DIFF
--- a/library/src/main/java/com/schibsted/spain/barista/interaction/BaristaAutoCompleteTextViewInteractions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/interaction/BaristaAutoCompleteTextViewInteractions.kt
@@ -5,13 +5,16 @@ import android.support.test.espresso.Espresso.onView
 import android.support.test.espresso.matcher.ViewMatchers.withId
 import com.schibsted.spain.barista.interaction.BaristaScrollInteractions.safelyScrollTo
 import com.schibsted.spain.barista.internal.matcher.DisplayedMatchers.displayedAnd
+import com.schibsted.spain.barista.internal.util.KeyboardAction
+import com.schibsted.spain.barista.internal.util.findAction
 import com.schibsted.spain.barista.internal.viewaction.AutoCompleteViewActions.replaceAutoComplete
 
 object BaristaAutoCompleteTextViewInteractions {
 
-    @JvmStatic
-    fun writeToAutoComplete(@IdRes autoCompleteId: Int, text: String) {
-        safelyScrollTo(autoCompleteId)
-        onView(displayedAnd(withId(autoCompleteId))).perform(replaceAutoComplete(text))
-    }
+  @JvmStatic
+  @JvmOverloads
+  fun writeToAutoComplete(@IdRes autoCompleteId: Int, text: String, action: KeyboardAction? = KeyboardAction.CLOSE) {
+    safelyScrollTo(autoCompleteId)
+    onView(displayedAnd(withId(autoCompleteId))).perform(replaceAutoComplete(text), findAction(action))
+  }
 }

--- a/library/src/main/java/com/schibsted/spain/barista/interaction/BaristaEditTextInteractions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/interaction/BaristaEditTextInteractions.kt
@@ -6,12 +6,15 @@ import android.support.test.espresso.action.ViewActions.replaceText
 import android.support.test.espresso.matcher.ViewMatchers.withId
 import com.schibsted.spain.barista.interaction.BaristaScrollInteractions.safelyScrollTo
 import com.schibsted.spain.barista.internal.matcher.DisplayedMatchers.displayedAnd
+import com.schibsted.spain.barista.internal.util.KeyboardAction
+import com.schibsted.spain.barista.internal.util.findAction
 
 object BaristaEditTextInteractions {
 
-    @JvmStatic
-    fun writeTo(@IdRes editTextId: Int, text: String) {
-        safelyScrollTo(editTextId)
-        onView(displayedAnd(withId(editTextId))).perform(replaceText(text))
-    }
+  @JvmStatic
+  @JvmOverloads
+  fun writeTo(@IdRes editTextId: Int, text: String, action: KeyboardAction? = KeyboardAction.CLOSE) {
+    safelyScrollTo(editTextId)
+    onView(displayedAnd(withId(editTextId))).perform(replaceText(text), findAction(action))
+  }
 }

--- a/library/src/main/java/com/schibsted/spain/barista/internal/util/KeyboardActions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/internal/util/KeyboardActions.kt
@@ -1,0 +1,11 @@
+package com.schibsted.spain.barista.internal.util
+
+import android.support.test.espresso.ViewAction
+import android.support.test.espresso.action.ViewActions
+
+enum class KeyboardAction { CLOSE, SUBMIT }
+
+fun findAction(action: KeyboardAction?): ViewAction = when (action) {
+  KeyboardAction.SUBMIT -> ViewActions.pressImeActionButton()
+  else -> ViewActions.closeSoftKeyboard()
+}

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AutoCompleteTextViewTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AutoCompleteTextViewTest.java
@@ -2,6 +2,7 @@ package com.schibsted.spain.barista.sample;
 
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
+import com.schibsted.spain.barista.internal.util.KeyboardAction;
 import com.schibsted.spain.barista.sample.util.FailureHandlerValidatorRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -9,6 +10,7 @@ import org.junit.runner.RunWith;
 
 import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertDisplayed;
 import static com.schibsted.spain.barista.interaction.BaristaAutoCompleteTextViewInteractions.writeToAutoComplete;
+import static com.schibsted.spain.barista.interaction.BaristaEditTextInteractions.writeTo;
 
 @RunWith(AndroidJUnit4.class)
 public class AutoCompleteTextViewTest {
@@ -35,5 +37,18 @@ public class AutoCompleteTextViewTest {
   public void checkWriteOnAutoComplete_whenParentIsNotAScrollView() {
     writeToAutoComplete(R.id.autocomplete_centered, "Hello!");
     assertDisplayed("Hello!");
+  }
+
+  @Test
+  public void checkWriteAndCloseOnAutoComplete_whenIsVisible() {
+    writeTo(R.id.autocomplete_centered, "Hello!", KeyboardAction.CLOSE);
+    assertDisplayed("Hello!");
+  }
+
+  @Test
+  public void checkWriteAndSubmitOnOnAutoComplete_whenVisible() {
+    writeTo(R.id.autocomplete_centered, "Hello!", KeyboardAction.SUBMIT);
+    assertDisplayed("Hello!");
+    assertDisplayed("Submitted!");
   }
 }

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/EditTextTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/EditTextTest.java
@@ -2,6 +2,7 @@ package com.schibsted.spain.barista.sample;
 
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
+import com.schibsted.spain.barista.internal.util.KeyboardAction;
 import com.schibsted.spain.barista.sample.util.FailureHandlerValidatorRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -10,6 +11,7 @@ import org.junit.runner.RunWith;
 import static com.schibsted.spain.barista.assertion.BaristaHintAssertions.assertHint;
 import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertDisplayed;
 import static com.schibsted.spain.barista.interaction.BaristaEditTextInteractions.writeTo;
+import static com.schibsted.spain.barista.interaction.BaristaScrollInteractions.safelyScrollTo;
 
 @RunWith(AndroidJUnit4.class)
 public class EditTextTest {
@@ -29,6 +31,7 @@ public class EditTextTest {
   @Test
   public void checkWriteOnEditText_whenScrollIsNeeded() {
     writeTo(R.id.edittext_very_far_away, "Hello!");
+    safelyScrollTo(R.id.edittext_very_far_away);
     assertDisplayed("Hello!");
   }
 
@@ -36,6 +39,19 @@ public class EditTextTest {
   public void checkWriteOnEditText_whenParentIsNotAScrollView() {
     writeTo(R.id.edittext_centered, "Hello!");
     assertDisplayed("Hello!");
+  }
+
+  @Test
+  public void checkWriteAndCloseOnEditText_whenEditTextIsVisible() {
+    writeTo(R.id.edittext, "Hello!", KeyboardAction.CLOSE);
+    assertDisplayed("Hello!");
+  }
+
+  @Test
+  public void checkWriteAndSubmitOnEditText_whenEditTextIsVisible() {
+    writeTo(R.id.edittext, "Hello!", KeyboardAction.SUBMIT);
+    assertDisplayed("Hello!");
+    assertDisplayed("Submitted!");
   }
 
   @Test

--- a/sample/src/main/java/com/schibsted/spain/barista/sample/AutoCompleteTextViewActivity.java
+++ b/sample/src/main/java/com/schibsted/spain/barista/sample/AutoCompleteTextViewActivity.java
@@ -2,8 +2,11 @@ package com.schibsted.spain.barista.sample;
 
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
+import android.view.KeyEvent;
 import android.widget.ArrayAdapter;
 import android.widget.AutoCompleteTextView;
+import android.widget.EditText;
+import android.widget.TextView;
 
 public class AutoCompleteTextViewActivity extends AppCompatActivity {
 
@@ -19,8 +22,18 @@ public class AutoCompleteTextViewActivity extends AppCompatActivity {
 
     autoComplete.setAdapter(new ArrayAdapter(this, android.R.layout.simple_list_item_1, FRUITS));
     autoComplete.setThreshold(1);
+    autoComplete.setOnEditorActionListener(new PutActionsOnTextView());
 
     veryFarAwayAutoComplete.setAdapter(new ArrayAdapter(this, android.R.layout.simple_list_item_1, FRUITS));
     veryFarAwayAutoComplete.setThreshold(1);
+  }
+
+  private class PutActionsOnTextView implements EditText.OnEditorActionListener {
+    @Override
+    public boolean onEditorAction(TextView editText, int actionId, KeyEvent keyEvent) {
+      TextView textView = (TextView) findViewById(R.id.actions);
+      textView.setText("Submitted!");
+      return true;
+    }
   }
 }

--- a/sample/src/main/java/com/schibsted/spain/barista/sample/EditTextActivity.java
+++ b/sample/src/main/java/com/schibsted/spain/barista/sample/EditTextActivity.java
@@ -17,7 +17,7 @@ public class EditTextActivity extends AppCompatActivity {
     editText.setOnEditorActionListener(new PutActionsOnTextView());
   }
 
-  private class PutActionsOnTextView implements EditText.OnEditorActionListener{
+  private class PutActionsOnTextView implements EditText.OnEditorActionListener {
     @Override
     public boolean onEditorAction(TextView editText, int actionId, KeyEvent keyEvent) {
       TextView textView = (TextView) findViewById(R.id.actions);

--- a/sample/src/main/java/com/schibsted/spain/barista/sample/EditTextActivity.java
+++ b/sample/src/main/java/com/schibsted/spain/barista/sample/EditTextActivity.java
@@ -2,6 +2,9 @@ package com.schibsted.spain.barista.sample;
 
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
+import android.view.KeyEvent;
+import android.widget.EditText;
+import android.widget.TextView;
 
 public class EditTextActivity extends AppCompatActivity {
 
@@ -9,5 +12,17 @@ public class EditTextActivity extends AppCompatActivity {
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
     setContentView(R.layout.activity_edittext);
+
+    EditText editText = (EditText) findViewById(R.id.edittext);
+    editText.setOnEditorActionListener(new PutActionsOnTextView());
+  }
+
+  private class PutActionsOnTextView implements EditText.OnEditorActionListener{
+    @Override
+    public boolean onEditorAction(TextView editText, int actionId, KeyEvent keyEvent) {
+      TextView textView = (TextView) findViewById(R.id.actions);
+      textView.setText("Submitted!");
+      return true;
+    }
   }
 }

--- a/sample/src/main/res/layout/activity_autocompletetextview.xml
+++ b/sample/src/main/res/layout/activity_autocompletetextview.xml
@@ -28,10 +28,25 @@
     </LinearLayout>
   </ScrollView>
 
-  <AutoCompleteTextView
-      android:id="@+id/autocomplete_centered"
-      android:layout_width="wrap_content"
+  <LinearLayout
+      android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:layout_gravity="center"
-      android:hint="I'm a centered autocomplete!"/>
+      android:orientation="vertical"
+      >
+
+    <AutoCompleteTextView
+        android:id="@+id/autocomplete_centered"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:hint="I'm a centered autocomplete!"/>
+
+    <TextView
+        android:id="@+id/actions"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="@android:color/white"
+        />
+  </LinearLayout>
+
 </FrameLayout>

--- a/sample/src/main/res/layout/activity_edittext.xml
+++ b/sample/src/main/res/layout/activity_edittext.xml
@@ -1,37 +1,58 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    >
 
   <ScrollView
       android:layout_width="match_parent"
-      android:layout_height="match_parent">
+      android:layout_height="match_parent"
+      >
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical">
+        android:orientation="vertical"
+        >
 
       <EditText
           android:id="@+id/edittext"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:hint="I'm an edittext"/>
+          android:hint="I'm an edittext"
+          />
 
       <EditText
           android:id="@+id/edittext_very_far_away"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginTop="800dp"
-          android:hint="I'm an edittext, too!"/>
+          android:layout_marginTop="8000dp"
+          android:hint="I'm an edittext, too!"
+          />
 
     </LinearLayout>
   </ScrollView>
 
-  <EditText
-      android:id="@+id/edittext_centered"
-      android:layout_width="wrap_content"
+  <LinearLayout
+      android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:layout_gravity="center"
-      android:hint="@string/centered_edittext"/>
+      android:orientation="vertical"
+      >
+
+    <EditText
+        android:id="@+id/edittext_centered"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:hint="@string/centered_edittext"
+        />
+
+    <TextView
+        android:id="@+id/actions"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="@android:color/white"
+        />
+  </LinearLayout>
+
 </FrameLayout>


### PR DESCRIPTION
This PR tries to solve https://github.com/SchibstedSpain/Barista/issues/183

It seems to me that by default it should close the keyboard after writing.

