### PR TITLE
Fixes wrong error handling on assertDisplayed

### DIFF
--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaVisibilityAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaVisibilityAssertions.kt
@@ -36,18 +36,23 @@ object BaristaVisibilityAssertions {
         onView(withId(resId)).check(matches(withText(text)))
     }
 
+    /**
+     * Attempts to find the view with multiple conditions:
+     * 1. Simplest case
+     * 2. More than one view
+     */
     private fun assertDisplayed(matcher: Matcher<View>) {
         val spyFailureHandler = SpyFailureHandler()
         try {
             onView(matcher)
                     .withFailureHandler(spyFailureHandler)
                     .check(matches(isDisplayed()))
-        } catch (multipleViews: AmbiguousViewMatcherException) {
+        } catch (firstError: Exception) {
             try {
                 onView(HelperMatchers.firstViewOf(allOf(matcher, isDisplayed())))
                         .withFailureHandler(spyFailureHandler)
                         .check(matches(isDisplayed()))
-            } catch (notDisplayedError: NoMatchingViewException) {
+            } catch (secondError: Exception) {
                 spyFailureHandler.resendFirstError("View ${matcher.description()} wasn't displayed on the screen")
             }
         }

--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaVisibilityAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaVisibilityAssertions.kt
@@ -47,12 +47,12 @@ object BaristaVisibilityAssertions {
             onView(matcher)
                     .withFailureHandler(spyFailureHandler)
                     .check(matches(isDisplayed()))
-        } catch (firstError: Exception) {
+        } catch (firstError: RuntimeException) {
             try {
                 onView(HelperMatchers.firstViewOf(allOf(matcher, isDisplayed())))
                         .withFailureHandler(spyFailureHandler)
                         .check(matches(isDisplayed()))
-            } catch (secondError: Exception) {
+            } catch (secondError: RuntimeException) {
                 spyFailureHandler.resendFirstError("View ${matcher.description()} wasn't displayed on the screen")
             }
         }

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertionsTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertionsTest.java
@@ -1,9 +1,9 @@
 package com.schibsted.spain.barista.sample;
 
-import android.support.test.espresso.NoMatchingViewException;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
 
+import com.schibsted.spain.barista.internal.failurehandler.BaristaException;
 import com.schibsted.spain.barista.internal.util.BaristaArgumentTypeException;
 
 import junit.framework.AssertionFailedError;
@@ -402,7 +402,7 @@ public class AssertionsTest {
     assertContains("Enabled");
   }
 
-  @Test(expected = NoMatchingViewException.class)
+  @Test(expected = BaristaException.class)
   public void checkTextViewContainsText_withoutViewId_failsWhenNeeded() {
     assertContains("unexisting text");
   }

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/FailureHandlerTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/FailureHandlerTest.java
@@ -1,0 +1,56 @@
+package com.schibsted.spain.barista.sample;
+
+import android.support.test.espresso.Espresso;
+import android.support.test.rule.ActivityTestRule;
+import com.schibsted.spain.barista.internal.failurehandler.SpyFailureHandler;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertDisplayed;
+import static org.junit.Assert.assertEquals;
+
+public class FailureHandlerTest {
+
+  private static final String NON_EXISTING = "The cake is a lie";
+
+  @Rule
+  public ActivityTestRule<SomeViewsWithDifferentVisibilitiesActivity> activityRule =
+      new ActivityTestRule<>(SomeViewsWithDifferentVisibilitiesActivity.class);
+
+  private SpyFailureHandler baseFailureHandler;
+
+  @Before
+  public void setUp() throws Exception {
+    baseFailureHandler = new SpyFailureHandler();
+    Espresso.setFailureHandler(baseFailureHandler);
+  }
+
+  @Test
+  public void baseFailureHandlerCalledOnce_withBarista() throws Exception {
+    try {
+      assertDisplayed(NON_EXISTING);
+    } catch (Exception ignored) {
+    }
+
+    assertBaseHandlerCalledOnce();
+  }
+
+  @Test
+  public void baseFailureHandlerCalledOnce_withEspresso() throws Exception {
+    try {
+      onView(withText(NON_EXISTING)).check(matches(isDisplayed()));
+    } catch (Exception ignored) {
+    }
+
+    assertBaseHandlerCalledOnce();
+  }
+
+  private void assertBaseHandlerCalledOnce() {
+    assertEquals(1, baseFailureHandler.getCapturedFailures().size());
+  }
+}

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/FailureHandlerTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/FailureHandlerTest.java
@@ -34,7 +34,7 @@ public class FailureHandlerTest {
   public void baseFailureHandlerCalledOnce_withBarista() throws Exception {
     try {
       assertDisplayed(NON_EXISTING);
-    } catch (Exception ignored) {
+    } catch (RuntimeException ignored) {
     }
 
     assertBaseHandlerCalledOnce();
@@ -44,7 +44,7 @@ public class FailureHandlerTest {
   public void baseFailureHandlerCalledOnce_withEspresso() throws Exception {
     try {
       onView(withText(NON_EXISTING)).check(matches(isDisplayed()));
-    } catch (Exception ignored) {
+    } catch (RuntimeException ignored) {
     }
 
     assertBaseHandlerCalledOnce();


### PR DESCRIPTION
While developing on https://github.com/Sloy/android-screenshot-reporter, which uses a FailureHandler to take screenshots on errors, I realised that the magic in assertDisplayed method wasn't behaving as expected.

**How should it work:**
When you call `assertDisplayed(id|text)` and the condition doesn't match -> you should receive **one and only one** error in your global Espresso's FailureHandler. Either the default `DefaultFailureHandler` or your own setted with `Espresso.setFailureHandler(custom)`. 
That happens thanks to `SpyFailureHandler.resendFirstError(...)`.

**How is it working now:**
When you call `assertDisplayed(id|text)` and the condition doesn't match -> The exception is simply thrown and your FailureHandler doesn't get notified.

The cause was a wrong logic on the try/catch flow. We were only rethrowing in case of `AmbiguousViewMatcherException`, which is not often the case.

Well, this PR fixes it.