### PR TITLE
Introduce generic assertAnyView function

### DIFF
--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaBackgroundAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaBackgroundAssertions.kt
@@ -2,28 +2,25 @@ package com.schibsted.spain.barista.assertion
 
 import android.support.annotation.DrawableRes
 import android.support.annotation.IdRes
-import android.support.test.espresso.Espresso
-import android.support.test.espresso.Espresso.*
-import android.support.test.espresso.assertion.ViewAssertions
-import android.support.test.espresso.assertion.ViewAssertions.*
-import android.support.test.espresso.matcher.ViewMatchers
-import com.schibsted.spain.barista.internal.matcher.BackgroundMatcher
-import com.schibsted.spain.barista.internal.matcher.DrawableMatcher
+import com.schibsted.spain.barista.internal.magicAssert
+import com.schibsted.spain.barista.internal.matcher.BackgroundMatcher.Companion.withAnyBackground
+import com.schibsted.spain.barista.internal.matcher.BackgroundMatcher.Companion.withBackground
+import com.schibsted.spain.barista.internal.matcher.BackgroundMatcher.Companion.withoutBackground
 
 object BaristaBackgroundAssertions {
 
-  @JvmStatic
-  fun assertHasBackground(@IdRes id: Int, @DrawableRes drawable: Int) {
-    onView(ViewMatchers.withId(id)).check(matches(BackgroundMatcher.withBackground(drawable)))
-  }
+    @JvmStatic
+    fun assertHasBackground(@IdRes viewId: Int, @DrawableRes drawable: Int) {
+        viewId magicAssert withBackground(drawable)
+    }
 
-  @JvmStatic
-  fun assertHasAnyBackground(@IdRes id: Int) {
-    onView(ViewMatchers.withId(id)).check(matches(BackgroundMatcher.withAnyBackground()))
-  }
+    @JvmStatic
+    fun assertHasAnyBackground(@IdRes viewId: Int) {
+        viewId magicAssert withAnyBackground()
+    }
 
-  @JvmStatic
-  fun assertHasNoBackground(@IdRes id: Int) {
-    onView(ViewMatchers.withId(id)).check(matches(BackgroundMatcher.withoutBackground()))
-  }
+    @JvmStatic
+    fun assertHasNoBackground(@IdRes viewId: Int) {
+        viewId magicAssert withoutBackground()
+    }
 }

--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaBackgroundAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaBackgroundAssertions.kt
@@ -2,7 +2,7 @@ package com.schibsted.spain.barista.assertion
 
 import android.support.annotation.DrawableRes
 import android.support.annotation.IdRes
-import com.schibsted.spain.barista.internal.magicAssert
+import com.schibsted.spain.barista.internal.assertAny
 import com.schibsted.spain.barista.internal.matcher.BackgroundMatcher.Companion.withAnyBackground
 import com.schibsted.spain.barista.internal.matcher.BackgroundMatcher.Companion.withBackground
 import com.schibsted.spain.barista.internal.matcher.BackgroundMatcher.Companion.withoutBackground
@@ -12,16 +12,16 @@ object BaristaBackgroundAssertions {
 
     @JvmStatic
     fun assertHasBackground(@IdRes viewId: Int, @DrawableRes drawable: Int) {
-        viewId.resourceMatcher().magicAssert(withBackground(drawable))
+        viewId.resourceMatcher().assertAny(withBackground(drawable))
     }
 
     @JvmStatic
     fun assertHasAnyBackground(@IdRes viewId: Int) {
-        viewId.resourceMatcher().magicAssert(withAnyBackground())
+        viewId.resourceMatcher().assertAny(withAnyBackground())
     }
 
     @JvmStatic
     fun assertHasNoBackground(@IdRes viewId: Int) {
-        viewId.resourceMatcher().magicAssert(withoutBackground())
+        viewId.resourceMatcher().assertAny(withoutBackground())
     }
 }

--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaBackgroundAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaBackgroundAssertions.kt
@@ -6,21 +6,22 @@ import com.schibsted.spain.barista.internal.magicAssert
 import com.schibsted.spain.barista.internal.matcher.BackgroundMatcher.Companion.withAnyBackground
 import com.schibsted.spain.barista.internal.matcher.BackgroundMatcher.Companion.withBackground
 import com.schibsted.spain.barista.internal.matcher.BackgroundMatcher.Companion.withoutBackground
+import com.schibsted.spain.barista.internal.util.resourceMatcher
 
 object BaristaBackgroundAssertions {
 
     @JvmStatic
     fun assertHasBackground(@IdRes viewId: Int, @DrawableRes drawable: Int) {
-        viewId magicAssert withBackground(drawable)
+        viewId.resourceMatcher().magicAssert(withBackground(drawable))
     }
 
     @JvmStatic
     fun assertHasAnyBackground(@IdRes viewId: Int) {
-        viewId magicAssert withAnyBackground()
+        viewId.resourceMatcher().magicAssert(withAnyBackground())
     }
 
     @JvmStatic
     fun assertHasNoBackground(@IdRes viewId: Int) {
-        viewId magicAssert withoutBackground()
+        viewId.resourceMatcher().magicAssert(withoutBackground())
     }
 }

--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaCheckedAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaCheckedAssertions.kt
@@ -1,29 +1,28 @@
 package com.schibsted.spain.barista.assertion
 
-import android.support.test.espresso.Espresso.onView
-import android.support.test.espresso.assertion.ViewAssertions.matches
-import android.support.test.espresso.matcher.ViewMatchers.*
-import com.schibsted.spain.barista.internal.util.resourceMatcher
+import android.support.test.espresso.matcher.ViewMatchers.isChecked
+import com.schibsted.spain.barista.internal.magicAssert
+import com.schibsted.spain.barista.internal.not
 
 object BaristaCheckedAssertions {
 
     @JvmStatic
     fun assertChecked(resId: Int) {
-        onView(resId.resourceMatcher()).check(matches(isChecked()))
+        resId magicAssert isChecked()
     }
 
     @JvmStatic
     fun assertChecked(text: String) {
-        onView(withText(text)).check(matches(isChecked()))
+        text magicAssert isChecked()
     }
 
     @JvmStatic
     fun assertUnchecked(resId: Int) {
-        onView(resId.resourceMatcher()).check(matches(isNotChecked()))
+        resId magicAssert !isChecked()
     }
 
     @JvmStatic
     fun assertUnchecked(text: String) {
-        onView(withText(text)).check(matches(isNotChecked()))
+        text magicAssert !isChecked()
     }
 }

--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaCheckedAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaCheckedAssertions.kt
@@ -2,7 +2,7 @@ package com.schibsted.spain.barista.assertion
 
 import android.support.test.espresso.matcher.ViewMatchers.isChecked
 import android.support.test.espresso.matcher.ViewMatchers.withText
-import com.schibsted.spain.barista.internal.magicAssert
+import com.schibsted.spain.barista.internal.assertAny
 import com.schibsted.spain.barista.internal.util.resourceMatcher
 import org.hamcrest.Matchers.not
 
@@ -10,21 +10,21 @@ object BaristaCheckedAssertions {
 
     @JvmStatic
     fun assertChecked(resId: Int) {
-        resId.resourceMatcher().magicAssert(isChecked())
+        resId.resourceMatcher().assertAny(isChecked())
     }
 
     @JvmStatic
     fun assertChecked(text: String) {
-        withText(text).magicAssert(isChecked())
+        withText(text).assertAny(isChecked())
     }
 
     @JvmStatic
     fun assertUnchecked(resId: Int) {
-        resId.resourceMatcher().magicAssert(not(isChecked()))
+        resId.resourceMatcher().assertAny(not(isChecked()))
     }
 
     @JvmStatic
     fun assertUnchecked(text: String) {
-        withText(text).magicAssert(not(isChecked()))
+        withText(text).assertAny(not(isChecked()))
     }
 }

--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaCheckedAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaCheckedAssertions.kt
@@ -2,7 +2,7 @@ package com.schibsted.spain.barista.assertion
 
 import android.support.test.espresso.matcher.ViewMatchers.isChecked
 import com.schibsted.spain.barista.internal.magicAssert
-import com.schibsted.spain.barista.internal.not
+import org.hamcrest.Matchers.not
 
 object BaristaCheckedAssertions {
 
@@ -18,11 +18,11 @@ object BaristaCheckedAssertions {
 
     @JvmStatic
     fun assertUnchecked(resId: Int) {
-        resId magicAssert !isChecked()
+        resId magicAssert not(isChecked())
     }
 
     @JvmStatic
     fun assertUnchecked(text: String) {
-        text magicAssert !isChecked()
+        text magicAssert not(isChecked())
     }
 }

--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaCheckedAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaCheckedAssertions.kt
@@ -1,28 +1,30 @@
 package com.schibsted.spain.barista.assertion
 
 import android.support.test.espresso.matcher.ViewMatchers.isChecked
+import android.support.test.espresso.matcher.ViewMatchers.withText
 import com.schibsted.spain.barista.internal.magicAssert
+import com.schibsted.spain.barista.internal.util.resourceMatcher
 import org.hamcrest.Matchers.not
 
 object BaristaCheckedAssertions {
 
     @JvmStatic
     fun assertChecked(resId: Int) {
-        resId magicAssert isChecked()
+        resId.resourceMatcher().magicAssert(isChecked())
     }
 
     @JvmStatic
     fun assertChecked(text: String) {
-        text magicAssert isChecked()
+        withText(text).magicAssert(isChecked())
     }
 
     @JvmStatic
     fun assertUnchecked(resId: Int) {
-        resId magicAssert not(isChecked())
+        resId.resourceMatcher().magicAssert(not(isChecked()))
     }
 
     @JvmStatic
     fun assertUnchecked(text: String) {
-        text magicAssert not(isChecked())
+        withText(text).magicAssert(not(isChecked()))
     }
 }

--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaEnabledAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaEnabledAssertions.kt
@@ -1,28 +1,30 @@
 package com.schibsted.spain.barista.assertion
 
 import android.support.test.espresso.matcher.ViewMatchers.isEnabled
+import android.support.test.espresso.matcher.ViewMatchers.withText
 import com.schibsted.spain.barista.internal.magicAssert
+import com.schibsted.spain.barista.internal.util.resourceMatcher
 import org.hamcrest.Matchers.not
 
 object BaristaEnabledAssertions {
 
     @JvmStatic
     fun assertEnabled(resId: Int) {
-        resId magicAssert isEnabled()
+        resId.resourceMatcher().magicAssert(isEnabled())
     }
 
     @JvmStatic
     fun assertEnabled(text: String) {
-        text magicAssert isEnabled()
+        withText(text).magicAssert(isEnabled())
     }
 
     @JvmStatic
     fun assertDisabled(resId: Int) {
-        resId magicAssert not(isEnabled())
+        resId.resourceMatcher().magicAssert(not(isEnabled()))
     }
 
     @JvmStatic
     fun assertDisabled(text: String) {
-        text magicAssert not(isEnabled())
+        withText(text).magicAssert(not(isEnabled()))
     }
 }

--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaEnabledAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaEnabledAssertions.kt
@@ -2,7 +2,7 @@ package com.schibsted.spain.barista.assertion
 
 import android.support.test.espresso.matcher.ViewMatchers.isEnabled
 import android.support.test.espresso.matcher.ViewMatchers.withText
-import com.schibsted.spain.barista.internal.magicAssert
+import com.schibsted.spain.barista.internal.assertAny
 import com.schibsted.spain.barista.internal.util.resourceMatcher
 import org.hamcrest.Matchers.not
 
@@ -10,21 +10,21 @@ object BaristaEnabledAssertions {
 
     @JvmStatic
     fun assertEnabled(resId: Int) {
-        resId.resourceMatcher().magicAssert(isEnabled())
+        resId.resourceMatcher().assertAny(isEnabled())
     }
 
     @JvmStatic
     fun assertEnabled(text: String) {
-        withText(text).magicAssert(isEnabled())
+        withText(text).assertAny(isEnabled())
     }
 
     @JvmStatic
     fun assertDisabled(resId: Int) {
-        resId.resourceMatcher().magicAssert(not(isEnabled()))
+        resId.resourceMatcher().assertAny(not(isEnabled()))
     }
 
     @JvmStatic
     fun assertDisabled(text: String) {
-        withText(text).magicAssert(not(isEnabled()))
+        withText(text).assertAny(not(isEnabled()))
     }
 }

--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaEnabledAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaEnabledAssertions.kt
@@ -2,7 +2,7 @@ package com.schibsted.spain.barista.assertion
 
 import android.support.test.espresso.matcher.ViewMatchers.isEnabled
 import com.schibsted.spain.barista.internal.magicAssert
-import com.schibsted.spain.barista.internal.not
+import org.hamcrest.Matchers.not
 
 object BaristaEnabledAssertions {
 
@@ -18,11 +18,11 @@ object BaristaEnabledAssertions {
 
     @JvmStatic
     fun assertDisabled(resId: Int) {
-        resId magicAssert !isEnabled()
+        resId magicAssert not(isEnabled())
     }
 
     @JvmStatic
     fun assertDisabled(text: String) {
-        text magicAssert !isEnabled()
+        text magicAssert not(isEnabled())
     }
 }

--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaEnabledAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaEnabledAssertions.kt
@@ -1,31 +1,28 @@
 package com.schibsted.spain.barista.assertion
 
-import android.support.test.espresso.Espresso.onView
-import android.support.test.espresso.assertion.ViewAssertions.matches
 import android.support.test.espresso.matcher.ViewMatchers.isEnabled
-import android.support.test.espresso.matcher.ViewMatchers.withText
-import com.schibsted.spain.barista.internal.util.resourceMatcher
-import org.hamcrest.core.IsNot.not
+import com.schibsted.spain.barista.internal.magicAssert
+import com.schibsted.spain.barista.internal.not
 
 object BaristaEnabledAssertions {
 
     @JvmStatic
     fun assertEnabled(resId: Int) {
-        onView(resId.resourceMatcher()).check(matches(isEnabled()))
+        resId magicAssert isEnabled()
     }
 
     @JvmStatic
     fun assertEnabled(text: String) {
-        onView(withText(text)).check(matches(isEnabled()))
+        text magicAssert isEnabled()
     }
 
     @JvmStatic
     fun assertDisabled(resId: Int) {
-        onView(resId.resourceMatcher()).check(matches(not(isEnabled())))
+        resId magicAssert !isEnabled()
     }
 
     @JvmStatic
     fun assertDisabled(text: String) {
-        onView(withText(text)).check(matches(not(isEnabled())))
+        text magicAssert !isEnabled()
     }
 }

--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaFocusedAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaFocusedAssertions.kt
@@ -3,7 +3,7 @@ package com.schibsted.spain.barista.assertion
 import android.support.annotation.IdRes
 import android.support.test.espresso.matcher.ViewMatchers.hasFocus
 import com.schibsted.spain.barista.internal.magicAssert
-import com.schibsted.spain.barista.internal.not
+import org.hamcrest.Matchers.not
 
 object BaristaFocusedAssertions {
 
@@ -14,7 +14,7 @@ object BaristaFocusedAssertions {
 
     @JvmStatic
     fun assertNotFocused(@IdRes resId: Int) {
-        resId magicAssert !hasFocus()
+        resId magicAssert not(hasFocus())
     }
 
     @JvmStatic
@@ -24,6 +24,6 @@ object BaristaFocusedAssertions {
 
     @JvmStatic
     fun assertNotFocused(text: String) {
-        text magicAssert !hasFocus()
+        text magicAssert not(hasFocus())
     }
 }

--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaFocusedAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaFocusedAssertions.kt
@@ -2,28 +2,30 @@ package com.schibsted.spain.barista.assertion
 
 import android.support.annotation.IdRes
 import android.support.test.espresso.matcher.ViewMatchers.hasFocus
+import android.support.test.espresso.matcher.ViewMatchers.withText
 import com.schibsted.spain.barista.internal.magicAssert
+import com.schibsted.spain.barista.internal.util.resourceMatcher
 import org.hamcrest.Matchers.not
 
 object BaristaFocusedAssertions {
 
     @JvmStatic
     fun assertFocused(resId: Int) {
-        resId magicAssert hasFocus()
+        resId.resourceMatcher().magicAssert(hasFocus())
     }
 
     @JvmStatic
     fun assertNotFocused(@IdRes resId: Int) {
-        resId magicAssert not(hasFocus())
+        resId.resourceMatcher().magicAssert(not(hasFocus()))
     }
 
     @JvmStatic
     fun assertFocused(text: String) {
-        text magicAssert hasFocus()
+        withText(text).magicAssert(hasFocus())
     }
 
     @JvmStatic
     fun assertNotFocused(text: String) {
-        text magicAssert not(hasFocus())
+        withText(text).magicAssert(not(hasFocus()))
     }
 }

--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaFocusedAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaFocusedAssertions.kt
@@ -3,7 +3,7 @@ package com.schibsted.spain.barista.assertion
 import android.support.annotation.IdRes
 import android.support.test.espresso.matcher.ViewMatchers.hasFocus
 import android.support.test.espresso.matcher.ViewMatchers.withText
-import com.schibsted.spain.barista.internal.magicAssert
+import com.schibsted.spain.barista.internal.assertAny
 import com.schibsted.spain.barista.internal.util.resourceMatcher
 import org.hamcrest.Matchers.not
 
@@ -11,21 +11,21 @@ object BaristaFocusedAssertions {
 
     @JvmStatic
     fun assertFocused(resId: Int) {
-        resId.resourceMatcher().magicAssert(hasFocus())
+        resId.resourceMatcher().assertAny(hasFocus())
     }
 
     @JvmStatic
     fun assertNotFocused(@IdRes resId: Int) {
-        resId.resourceMatcher().magicAssert(not(hasFocus()))
+        resId.resourceMatcher().assertAny(not(hasFocus()))
     }
 
     @JvmStatic
     fun assertFocused(text: String) {
-        withText(text).magicAssert(hasFocus())
+        withText(text).assertAny(hasFocus())
     }
 
     @JvmStatic
     fun assertNotFocused(text: String) {
-        withText(text).magicAssert(not(hasFocus()))
+        withText(text).assertAny(not(hasFocus()))
     }
 }

--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaFocusedAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaFocusedAssertions.kt
@@ -1,32 +1,29 @@
 package com.schibsted.spain.barista.assertion
 
 import android.support.annotation.IdRes
-import android.support.test.espresso.Espresso.onView
-import android.support.test.espresso.assertion.ViewAssertions.matches
 import android.support.test.espresso.matcher.ViewMatchers.hasFocus
-import android.support.test.espresso.matcher.ViewMatchers.withText
-import com.schibsted.spain.barista.internal.util.resourceMatcher
-import org.hamcrest.core.IsNot.not
+import com.schibsted.spain.barista.internal.magicAssert
+import com.schibsted.spain.barista.internal.not
 
 object BaristaFocusedAssertions {
 
     @JvmStatic
-    fun assertFocused(@IdRes resId: Int) {
-        onView(resId.resourceMatcher()).check(matches(hasFocus()))
+    fun assertFocused(resId: Int) {
+        resId magicAssert hasFocus()
     }
 
     @JvmStatic
     fun assertNotFocused(@IdRes resId: Int) {
-        onView(resId.resourceMatcher()).check(matches(not(hasFocus())))
+        resId magicAssert !hasFocus()
     }
 
     @JvmStatic
     fun assertFocused(text: String) {
-        onView(withText(text)).check(matches(hasFocus()))
+        text magicAssert hasFocus()
     }
 
     @JvmStatic
     fun assertNotFocused(text: String) {
-        onView(withText(text)).check(matches(not(hasFocus())))
+        text magicAssert !hasFocus()
     }
 }

--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaHintAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaHintAssertions.kt
@@ -4,18 +4,18 @@ import android.support.annotation.IdRes
 import android.support.annotation.StringRes
 import android.support.test.espresso.matcher.ViewMatchers.withHint
 import android.support.test.espresso.matcher.ViewMatchers.withId
-import com.schibsted.spain.barista.internal.magicAssert
+import com.schibsted.spain.barista.internal.assertAny
 
 object BaristaHintAssertions {
 
     @JvmStatic
     fun assertHint(@IdRes viewId: Int, @StringRes text: Int) {
-        withId(viewId).magicAssert(withHint(text))
+        withId(viewId).assertAny(withHint(text))
     }
 
     @JvmStatic
     fun assertHint(@IdRes viewId: Int, text: String) {
-        withId(viewId).magicAssert(withHint(text))
+        withId(viewId).assertAny(withHint(text))
     }
 
 }

--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaHintAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaHintAssertions.kt
@@ -10,12 +10,12 @@ object BaristaHintAssertions {
 
     @JvmStatic
     fun assertHint(@IdRes viewId: Int, @StringRes text: Int) {
-        withId(viewId) magicAssert withHint(text)
+        withId(viewId).magicAssert(withHint(text))
     }
 
     @JvmStatic
     fun assertHint(@IdRes viewId: Int, text: String) {
-        withId(viewId) magicAssert withHint(text)
+        withId(viewId).magicAssert(withHint(text))
     }
 
 }

--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaHintAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaHintAssertions.kt
@@ -2,21 +2,20 @@ package com.schibsted.spain.barista.assertion
 
 import android.support.annotation.IdRes
 import android.support.annotation.StringRes
-import android.support.test.espresso.Espresso.onView
-import android.support.test.espresso.assertion.ViewAssertions.matches
 import android.support.test.espresso.matcher.ViewMatchers.withHint
 import android.support.test.espresso.matcher.ViewMatchers.withId
+import com.schibsted.spain.barista.internal.magicAssert
 
 object BaristaHintAssertions {
 
     @JvmStatic
-    fun assertHint(@IdRes id: Int, @StringRes text: Int) {
-        onView(withId(id)).check(matches(withHint(text)))
+    fun assertHint(@IdRes viewId: Int, @StringRes text: Int) {
+        withId(viewId) magicAssert withHint(text)
     }
 
     @JvmStatic
-    fun assertHint(@IdRes id: Int, text: String) {
-        onView(withId(id)).check(matches(withHint(text)))
+    fun assertHint(@IdRes viewId: Int, text: String) {
+        withId(viewId) magicAssert withHint(text)
     }
 
 }

--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaImageViewAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaImageViewAssertions.kt
@@ -2,8 +2,6 @@ package com.schibsted.spain.barista.assertion
 
 import android.support.annotation.DrawableRes
 import android.support.annotation.IdRes
-import android.support.test.espresso.Espresso.onView
-import android.support.test.espresso.assertion.ViewAssertions.matches
 import android.support.test.espresso.matcher.ViewMatchers.withId
 import com.schibsted.spain.barista.internal.magicAssert
 import com.schibsted.spain.barista.internal.matcher.DrawableMatcher.Companion.withAnyDrawable
@@ -14,16 +12,16 @@ object BaristaImageViewAssertions {
 
     @JvmStatic
     fun assertHasDrawable(@IdRes imageViewId: Int, @DrawableRes drawable: Int) {
-        withId(imageViewId) magicAssert withDrawable(drawable)
+        withId(imageViewId).magicAssert(withDrawable(drawable))
     }
 
     @JvmStatic
     fun assertHasAnyDrawable(@IdRes imageViewId: Int) {
-        withId(imageViewId) magicAssert withAnyDrawable()
+        withId(imageViewId).magicAssert(withAnyDrawable())
     }
 
     @JvmStatic
     fun assertHasNoDrawable(@IdRes imageViewId: Int) {
-        withId(imageViewId) magicAssert withoutDrawable()
+        withId(imageViewId).magicAssert(withoutDrawable())
     }
 }

--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaImageViewAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaImageViewAssertions.kt
@@ -5,6 +5,7 @@ import android.support.annotation.IdRes
 import android.support.test.espresso.Espresso.onView
 import android.support.test.espresso.assertion.ViewAssertions.matches
 import android.support.test.espresso.matcher.ViewMatchers.withId
+import com.schibsted.spain.barista.internal.magicAssert
 import com.schibsted.spain.barista.internal.matcher.DrawableMatcher.Companion.withAnyDrawable
 import com.schibsted.spain.barista.internal.matcher.DrawableMatcher.Companion.withDrawable
 import com.schibsted.spain.barista.internal.matcher.DrawableMatcher.Companion.withoutDrawable
@@ -13,16 +14,16 @@ object BaristaImageViewAssertions {
 
     @JvmStatic
     fun assertHasDrawable(@IdRes imageViewId: Int, @DrawableRes drawable: Int) {
-        onView(withId(imageViewId)).check(matches(withDrawable(drawable)))
+        withId(imageViewId) magicAssert withDrawable(drawable)
     }
 
     @JvmStatic
     fun assertHasAnyDrawable(@IdRes imageViewId: Int) {
-        onView(withId(imageViewId)).check(matches(withAnyDrawable()))
+        withId(imageViewId) magicAssert withAnyDrawable()
     }
 
     @JvmStatic
     fun assertHasNoDrawable(@IdRes imageViewId: Int) {
-        onView(withId(imageViewId)).check(matches(withoutDrawable()))
+        withId(imageViewId) magicAssert withoutDrawable()
     }
 }

--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaImageViewAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaImageViewAssertions.kt
@@ -3,7 +3,7 @@ package com.schibsted.spain.barista.assertion
 import android.support.annotation.DrawableRes
 import android.support.annotation.IdRes
 import android.support.test.espresso.matcher.ViewMatchers.withId
-import com.schibsted.spain.barista.internal.magicAssert
+import com.schibsted.spain.barista.internal.assertAny
 import com.schibsted.spain.barista.internal.matcher.DrawableMatcher.Companion.withAnyDrawable
 import com.schibsted.spain.barista.internal.matcher.DrawableMatcher.Companion.withDrawable
 import com.schibsted.spain.barista.internal.matcher.DrawableMatcher.Companion.withoutDrawable
@@ -12,16 +12,16 @@ object BaristaImageViewAssertions {
 
     @JvmStatic
     fun assertHasDrawable(@IdRes imageViewId: Int, @DrawableRes drawable: Int) {
-        withId(imageViewId).magicAssert(withDrawable(drawable))
+        withId(imageViewId).assertAny(withDrawable(drawable))
     }
 
     @JvmStatic
     fun assertHasAnyDrawable(@IdRes imageViewId: Int) {
-        withId(imageViewId).magicAssert(withAnyDrawable())
+        withId(imageViewId).assertAny(withAnyDrawable())
     }
 
     @JvmStatic
     fun assertHasNoDrawable(@IdRes imageViewId: Int) {
-        withId(imageViewId).magicAssert(withoutDrawable())
+        withId(imageViewId).assertAny(withoutDrawable())
     }
 }

--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaVisibilityAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaVisibilityAssertions.kt
@@ -7,10 +7,10 @@ import android.support.test.espresso.assertion.ViewAssertions.doesNotExist
 import android.support.test.espresso.matcher.ViewMatchers.*
 import com.schibsted.spain.barista.internal.magicAssert
 import com.schibsted.spain.barista.internal.matcher.TextColorMatcher
-import com.schibsted.spain.barista.internal.not
 import com.schibsted.spain.barista.internal.util.resourceMatcher
 import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.Matchers.allOf
+import org.hamcrest.Matchers.not
 
 object BaristaVisibilityAssertions {
 
@@ -41,17 +41,17 @@ object BaristaVisibilityAssertions {
 
     @JvmStatic
     fun assertNotDisplayed(viewId: Int) {
-        viewId magicAssert !isDisplayed()
+        viewId magicAssert not(isDisplayed())
     }
 
     @JvmStatic
     fun assertNotDisplayed(text: String) {
-        text magicAssert !isDisplayed()
+        text magicAssert not(isDisplayed())
     }
 
     @JvmStatic
     fun assertNotDisplayed(@IdRes viewId: Int, text: String) {
-        viewId magicAssert !withText(text)
+        viewId magicAssert not(withText(text))
     }
 
     @JvmStatic
@@ -81,6 +81,6 @@ object BaristaVisibilityAssertions {
 
     @JvmStatic
     fun assertTextColorIsNot(@IdRes viewId: Int, @ColorRes colorRes: Int) {
-        viewId magicAssert !TextColorMatcher(colorRes)
+        viewId magicAssert not(TextColorMatcher(colorRes))
     }
 }

--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaVisibilityAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaVisibilityAssertions.kt
@@ -5,7 +5,7 @@ import android.support.annotation.IdRes
 import android.support.test.espresso.Espresso.onView
 import android.support.test.espresso.assertion.ViewAssertions.doesNotExist
 import android.support.test.espresso.matcher.ViewMatchers.*
-import com.schibsted.spain.barista.internal.magicAssert
+import com.schibsted.spain.barista.internal.assertAny
 import com.schibsted.spain.barista.internal.matcher.TextColorMatcher
 import com.schibsted.spain.barista.internal.util.resourceMatcher
 import org.hamcrest.CoreMatchers.containsString
@@ -16,17 +16,17 @@ object BaristaVisibilityAssertions {
 
     @JvmStatic
     fun assertDisplayed(viewId: Int) {
-        viewId.resourceMatcher().magicAssert(isDisplayed())
+        viewId.resourceMatcher().assertAny(isDisplayed())
     }
 
     @JvmStatic
     fun assertDisplayed(text: String) {
-        withText(text).magicAssert(isDisplayed())
+        withText(text).assertAny(isDisplayed())
     }
 
     @JvmStatic
     fun assertDisplayed(@IdRes viewId: Int, text: String) {
-        viewId.resourceMatcher().magicAssert(withText(text))
+        viewId.resourceMatcher().assertAny(withText(text))
     }
 
     @JvmStatic
@@ -41,27 +41,27 @@ object BaristaVisibilityAssertions {
 
     @JvmStatic
     fun assertNotDisplayed(viewId: Int) {
-        viewId.resourceMatcher().magicAssert(not(isDisplayed()))
+        viewId.resourceMatcher().assertAny(not(isDisplayed()))
     }
 
     @JvmStatic
     fun assertNotDisplayed(text: String) {
-        withText(text).magicAssert(not(isDisplayed()))
+        withText(text).assertAny(not(isDisplayed()))
     }
 
     @JvmStatic
     fun assertNotDisplayed(@IdRes viewId: Int, text: String) {
-        viewId.resourceMatcher().magicAssert(not(withText(text)))
+        viewId.resourceMatcher().assertAny(not(withText(text)))
     }
 
     @JvmStatic
     fun assertContains(text: String) {
-        withText(containsString(text)).magicAssert(isDisplayed())
+        withText(containsString(text)).assertAny(isDisplayed())
     }
 
     @JvmStatic
     fun assertContains(@IdRes viewId: Int, text: String) {
-        viewId.resourceMatcher().magicAssert(withText(containsString(text)))
+        viewId.resourceMatcher().assertAny(withText(containsString(text)))
     }
 
     @JvmStatic
@@ -76,11 +76,11 @@ object BaristaVisibilityAssertions {
 
     @JvmStatic
     fun assertTextColorIs(@IdRes viewId: Int, @ColorRes colorRes: Int) {
-        viewId.resourceMatcher().magicAssert(TextColorMatcher(colorRes))
+        viewId.resourceMatcher().assertAny(TextColorMatcher(colorRes))
     }
 
     @JvmStatic
     fun assertTextColorIsNot(@IdRes viewId: Int, @ColorRes colorRes: Int) {
-        viewId.resourceMatcher().magicAssert(not(TextColorMatcher(colorRes)))
+        viewId.resourceMatcher().assertAny(not(TextColorMatcher(colorRes)))
     }
 }

--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaVisibilityAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaVisibilityAssertions.kt
@@ -2,60 +2,31 @@ package com.schibsted.spain.barista.assertion
 
 import android.support.annotation.ColorRes
 import android.support.annotation.IdRes
-import android.support.test.espresso.AmbiguousViewMatcherException
 import android.support.test.espresso.Espresso.onView
-import android.support.test.espresso.NoMatchingViewException
 import android.support.test.espresso.assertion.ViewAssertions.doesNotExist
-import android.support.test.espresso.assertion.ViewAssertions.matches
 import android.support.test.espresso.matcher.ViewMatchers.*
-import android.view.View
-import com.schibsted.spain.barista.internal.failurehandler.SpyFailureHandler
-import com.schibsted.spain.barista.internal.failurehandler.description
-import com.schibsted.spain.barista.internal.matcher.HelperMatchers
+import com.schibsted.spain.barista.internal.magicAssert
 import com.schibsted.spain.barista.internal.matcher.TextColorMatcher
+import com.schibsted.spain.barista.internal.not
 import com.schibsted.spain.barista.internal.util.resourceMatcher
 import org.hamcrest.CoreMatchers.containsString
-import org.hamcrest.Matcher
 import org.hamcrest.Matchers.allOf
-import org.hamcrest.core.IsNot.not
 
 object BaristaVisibilityAssertions {
 
     @JvmStatic
-    fun assertDisplayed(resId: Int) {
-        assertDisplayed(resId.resourceMatcher())
+    fun assertDisplayed(viewId: Int) {
+        viewId magicAssert isDisplayed()
     }
 
     @JvmStatic
     fun assertDisplayed(text: String) {
-        assertDisplayed(withText(text))
+        text magicAssert isDisplayed()
     }
 
     @JvmStatic
-    fun assertDisplayed(@IdRes resId: Int, text: String) {
-        onView(withId(resId)).check(matches(withText(text)))
-    }
-
-    /**
-     * Attempts to find the view with multiple conditions:
-     * 1. Simplest case
-     * 2. More than one view
-     */
-    private fun assertDisplayed(matcher: Matcher<View>) {
-        val spyFailureHandler = SpyFailureHandler()
-        try {
-            onView(matcher)
-                    .withFailureHandler(spyFailureHandler)
-                    .check(matches(isDisplayed()))
-        } catch (firstError: RuntimeException) {
-            try {
-                onView(HelperMatchers.firstViewOf(allOf(matcher, isDisplayed())))
-                        .withFailureHandler(spyFailureHandler)
-                        .check(matches(isDisplayed()))
-            } catch (secondError: RuntimeException) {
-                spyFailureHandler.resendFirstError("View ${matcher.description()} wasn't displayed on the screen")
-            }
-        }
+    fun assertDisplayed(@IdRes viewId: Int, text: String) {
+        viewId magicAssert withText(text)
     }
 
     @JvmStatic
@@ -69,28 +40,28 @@ object BaristaVisibilityAssertions {
     }
 
     @JvmStatic
-    fun assertNotDisplayed(resId: Int) {
-        onView(resId.resourceMatcher()).check(matches(not(isDisplayed())))
+    fun assertNotDisplayed(viewId: Int) {
+        viewId magicAssert !isDisplayed()
     }
 
     @JvmStatic
     fun assertNotDisplayed(text: String) {
-        onView(withText(text)).check(matches(not(isDisplayed())))
+        text magicAssert !isDisplayed()
     }
 
     @JvmStatic
-    fun assertNotDisplayed(@IdRes resId: Int, text: String) {
-        onView(withId(resId)).check(matches(not(withText(text))))
+    fun assertNotDisplayed(@IdRes viewId: Int, text: String) {
+        viewId magicAssert !withText(text)
     }
 
     @JvmStatic
     fun assertContains(text: String) {
-        assertDisplayed(withText(containsString(text)))
+        withText(containsString(text)) magicAssert isDisplayed()
     }
 
     @JvmStatic
-    fun assertContains(@IdRes resId: Int, text: String) {
-        onView(withId(resId)).check(matches(withText(containsString(text))))
+    fun assertContains(@IdRes viewId: Int, text: String) {
+        viewId magicAssert withText(containsString(text))
     }
 
     @JvmStatic
@@ -104,12 +75,12 @@ object BaristaVisibilityAssertions {
     }
 
     @JvmStatic
-    fun assertTextColorIs(@IdRes resId: Int, @ColorRes colorRes: Int) {
-        onView(withId(resId)).check(matches(TextColorMatcher(colorRes)))
+    fun assertTextColorIs(@IdRes viewId: Int, @ColorRes colorRes: Int) {
+        viewId magicAssert TextColorMatcher(colorRes)
     }
 
     @JvmStatic
-    fun assertTextColorIsNot(@IdRes resId: Int, @ColorRes colorRes: Int) {
-        onView(withId(resId)).check(matches(not(TextColorMatcher(colorRes))))
+    fun assertTextColorIsNot(@IdRes viewId: Int, @ColorRes colorRes: Int) {
+        viewId magicAssert !TextColorMatcher(colorRes)
     }
 }

--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaVisibilityAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaVisibilityAssertions.kt
@@ -16,17 +16,17 @@ object BaristaVisibilityAssertions {
 
     @JvmStatic
     fun assertDisplayed(viewId: Int) {
-        viewId magicAssert isDisplayed()
+        viewId.resourceMatcher().magicAssert(isDisplayed())
     }
 
     @JvmStatic
     fun assertDisplayed(text: String) {
-        text magicAssert isDisplayed()
+        withText(text).magicAssert(isDisplayed())
     }
 
     @JvmStatic
     fun assertDisplayed(@IdRes viewId: Int, text: String) {
-        viewId magicAssert withText(text)
+        viewId.resourceMatcher().magicAssert(withText(text))
     }
 
     @JvmStatic
@@ -41,27 +41,27 @@ object BaristaVisibilityAssertions {
 
     @JvmStatic
     fun assertNotDisplayed(viewId: Int) {
-        viewId magicAssert not(isDisplayed())
+        viewId.resourceMatcher().magicAssert(not(isDisplayed()))
     }
 
     @JvmStatic
     fun assertNotDisplayed(text: String) {
-        text magicAssert not(isDisplayed())
+        withText(text).magicAssert(not(isDisplayed()))
     }
 
     @JvmStatic
     fun assertNotDisplayed(@IdRes viewId: Int, text: String) {
-        viewId magicAssert not(withText(text))
+        viewId.resourceMatcher().magicAssert(not(withText(text)))
     }
 
     @JvmStatic
     fun assertContains(text: String) {
-        withText(containsString(text)) magicAssert isDisplayed()
+        withText(containsString(text)).magicAssert(isDisplayed())
     }
 
     @JvmStatic
     fun assertContains(@IdRes viewId: Int, text: String) {
-        viewId magicAssert withText(containsString(text))
+        viewId.resourceMatcher().magicAssert(withText(containsString(text)))
     }
 
     @JvmStatic
@@ -76,11 +76,11 @@ object BaristaVisibilityAssertions {
 
     @JvmStatic
     fun assertTextColorIs(@IdRes viewId: Int, @ColorRes colorRes: Int) {
-        viewId magicAssert TextColorMatcher(colorRes)
+        viewId.resourceMatcher().magicAssert(TextColorMatcher(colorRes))
     }
 
     @JvmStatic
     fun assertTextColorIsNot(@IdRes viewId: Int, @ColorRes colorRes: Int) {
-        viewId magicAssert not(TextColorMatcher(colorRes))
+        viewId.resourceMatcher().magicAssert(not(TextColorMatcher(colorRes)))
     }
 }

--- a/library/src/main/java/com/schibsted/spain/barista/internal/AssertAny.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/internal/AssertAny.kt
@@ -6,15 +6,14 @@ import android.view.View
 import com.schibsted.spain.barista.internal.failurehandler.SpyFailureHandler
 import com.schibsted.spain.barista.internal.failurehandler.description
 import com.schibsted.spain.barista.internal.matcher.HelperMatchers.firstViewOf
-import com.schibsted.spain.barista.internal.util.resourceMatcher
 import org.hamcrest.Matcher
 import org.hamcrest.Matchers.allOf
 
 /**
- * Extension function alias for [magicAssertOnView]
+ * Extension function alias for [assertAnyView]
  */
-fun Matcher<View>.magicAssert(condition: Matcher<View>) {
-    magicAssertOnView(viewMatcher = this, condition = condition)
+fun Matcher<View>.assertAny(condition: Matcher<View>) {
+    assertAnyView(viewMatcher = this, condition = condition)
 }
 
 /**
@@ -24,7 +23,7 @@ fun Matcher<View>.magicAssert(condition: Matcher<View>) {
  * 1. Just one view matches the [viewMatcher].
  * 2. Multiple views match the [viewMatcher]: will pass if at least one of them matches the [condition].
  */
-fun magicAssertOnView(viewMatcher: Matcher<View>, condition: Matcher<View>) {
+fun assertAnyView(viewMatcher: Matcher<View>, condition: Matcher<View>) {
     val spyFailureHandler = SpyFailureHandler()
     try {
         tryToAssert(viewMatcher, condition, spyFailureHandler)

--- a/library/src/main/java/com/schibsted/spain/barista/internal/MagicAssert.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/internal/MagicAssert.kt
@@ -1,0 +1,63 @@
+package com.schibsted.spain.barista.internal
+
+import android.support.test.espresso.Espresso.onView
+import android.support.test.espresso.assertion.ViewAssertions
+import android.support.test.espresso.matcher.ViewMatchers.withText
+import android.view.View
+import com.schibsted.spain.barista.internal.failurehandler.SpyFailureHandler
+import com.schibsted.spain.barista.internal.failurehandler.description
+import com.schibsted.spain.barista.internal.matcher.HelperMatchers.firstViewOf
+import com.schibsted.spain.barista.internal.util.resourceMatcher
+import org.hamcrest.Matcher
+import org.hamcrest.Matchers.allOf
+import org.hamcrest.Matchers.not
+
+/**
+ * Extension function alias for [magicAssertOnView] supporting both Id or String resources.
+ */
+infix fun Int.magicAssert(condition: Matcher<View>) {
+    this.resourceMatcher() magicAssert condition
+}
+
+/**
+ * Extension function alias for [magicAssertOnView] using [withText] as viewMatcher
+ */
+infix fun String.magicAssert(condition: Matcher<View>) {
+    withText(this) magicAssert condition
+}
+
+/**
+ * Extension function alias for [magicAssertOnView]
+ */
+infix fun Matcher<View>.magicAssert(condition: Matcher<View>) {
+    magicAssertOnView(viewMatcher = this, condition = condition)
+}
+
+/**
+ * Performs an assertion of a [condition] on a view described by [viewMatcher].
+ *
+ * Attempts to assert using multiple scenarios for the [viewMatcher]:
+ * 1. Just one view matches the [viewMatcher].
+ * 2. Multiple views match the [viewMatcher]: will pass if at least one of them matches the [condition].
+ */
+fun magicAssertOnView(viewMatcher: Matcher<View>, condition: Matcher<View>) {
+    val spyFailureHandler = SpyFailureHandler()
+    try {
+        onView(viewMatcher)
+                .withFailureHandler(spyFailureHandler)
+                .check(ViewAssertions.matches(condition))
+    } catch (firstError: RuntimeException) {
+        try {
+            onView(firstViewOf(allOf(viewMatcher, condition)))
+                    .withFailureHandler(spyFailureHandler)
+                    .check(ViewAssertions.matches(condition))
+        } catch (secondError: RuntimeException) {
+            spyFailureHandler.resendFirstError("View ${viewMatcher.description()} wasn't displayed on the screen")
+        }
+    }
+}
+
+/**
+ * Allow using `!viewMatcher` as alias for `not(viewMatcher)`
+ */
+operator fun Matcher<View>.not(): Matcher<View> = not(this)

--- a/library/src/main/java/com/schibsted/spain/barista/internal/MagicAssert.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/internal/MagicAssert.kt
@@ -64,8 +64,3 @@ private fun tryToAssert(viewMatcher: Matcher<View>, condition: Matcher<View>, sp
             .withFailureHandler(spyFailureHandler)
             .check(ViewAssertions.matches(condition))
 }
-
-/**
- * Allow using `!viewMatcher` as alias for `not(viewMatcher)`
- */
-operator fun Matcher<View>.not(): Matcher<View> = not(this)

--- a/library/src/main/java/com/schibsted/spain/barista/internal/MagicAssert.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/internal/MagicAssert.kt
@@ -2,7 +2,6 @@ package com.schibsted.spain.barista.internal
 
 import android.support.test.espresso.Espresso.onView
 import android.support.test.espresso.assertion.ViewAssertions
-import android.support.test.espresso.matcher.ViewMatchers.withText
 import android.view.View
 import com.schibsted.spain.barista.internal.failurehandler.SpyFailureHandler
 import com.schibsted.spain.barista.internal.failurehandler.description
@@ -10,26 +9,11 @@ import com.schibsted.spain.barista.internal.matcher.HelperMatchers.firstViewOf
 import com.schibsted.spain.barista.internal.util.resourceMatcher
 import org.hamcrest.Matcher
 import org.hamcrest.Matchers.allOf
-import org.hamcrest.Matchers.not
-
-/**
- * Extension function alias for [magicAssertOnView] supporting both Id or String resources.
- */
-infix fun Int.magicAssert(condition: Matcher<View>) {
-    this.resourceMatcher() magicAssert condition
-}
-
-/**
- * Extension function alias for [magicAssertOnView] using [withText] as viewMatcher
- */
-infix fun String.magicAssert(condition: Matcher<View>) {
-    withText(this) magicAssert condition
-}
 
 /**
  * Extension function alias for [magicAssertOnView]
  */
-infix fun Matcher<View>.magicAssert(condition: Matcher<View>) {
+fun Matcher<View>.magicAssert(condition: Matcher<View>) {
     magicAssertOnView(viewMatcher = this, condition = condition)
 }
 

--- a/library/src/main/java/com/schibsted/spain/barista/internal/MagicAssert.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/internal/MagicAssert.kt
@@ -43,18 +43,26 @@ infix fun Matcher<View>.magicAssert(condition: Matcher<View>) {
 fun magicAssertOnView(viewMatcher: Matcher<View>, condition: Matcher<View>) {
     val spyFailureHandler = SpyFailureHandler()
     try {
-        onView(viewMatcher)
-                .withFailureHandler(spyFailureHandler)
-                .check(ViewAssertions.matches(condition))
+        tryToAssert(viewMatcher, condition, spyFailureHandler)
     } catch (firstError: RuntimeException) {
         try {
-            onView(firstViewOf(allOf(viewMatcher, condition)))
-                    .withFailureHandler(spyFailureHandler)
-                    .check(ViewAssertions.matches(condition))
+            tryToAssertFirstView(viewMatcher, condition, spyFailureHandler)
         } catch (secondError: RuntimeException) {
             spyFailureHandler.resendFirstError("View ${viewMatcher.description()} wasn't displayed on the screen")
         }
     }
+}
+
+private fun tryToAssertFirstView(viewMatcher: Matcher<View>, condition: Matcher<View>, spyFailureHandler: SpyFailureHandler) {
+    onView(firstViewOf(allOf(viewMatcher, condition)))
+            .withFailureHandler(spyFailureHandler)
+            .check(ViewAssertions.matches(condition))
+}
+
+private fun tryToAssert(viewMatcher: Matcher<View>, condition: Matcher<View>, spyFailureHandler: SpyFailureHandler) {
+    onView(viewMatcher)
+            .withFailureHandler(spyFailureHandler)
+            .check(ViewAssertions.matches(condition))
 }
 
 /**

--- a/library/src/main/java/com/schibsted/spain/barista/internal/util/ResourceType.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/internal/util/ResourceType.kt
@@ -6,7 +6,7 @@ import android.support.test.espresso.matcher.ViewMatchers.withText
 import android.view.View
 import org.hamcrest.Matcher
 
-class BaristaArgumentTypeException : RuntimeException("The id argument must be R.id.* or R.string.*")
+class BaristaResourceTypeException(message: String) : RuntimeException(message)
 
 enum class ResourceType {
     ID, STRING
@@ -18,7 +18,7 @@ val Int.resourceType: ResourceType
         return when (resourceTypeName) {
             "id" -> ResourceType.ID
             "string" -> ResourceType.STRING
-            else -> throw BaristaArgumentTypeException()
+            else -> throw BaristaResourceTypeException("The id argument must be R.id.* or R.string.*, but was $resourceTypeName")
         }
     }
 

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertionsTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertionsTest.java
@@ -4,7 +4,7 @@ import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
 
 import com.schibsted.spain.barista.internal.failurehandler.BaristaException;
-import com.schibsted.spain.barista.internal.util.BaristaArgumentTypeException;
+import com.schibsted.spain.barista.internal.util.BaristaResourceTypeException;
 
 import junit.framework.AssertionFailedError;
 
@@ -274,37 +274,37 @@ public class AssertionsTest {
     try {
       assertDisplayed(R.color.colorAccent);
       fail();
-    } catch (BaristaArgumentTypeException expected) {
+    } catch (BaristaResourceTypeException expected) {
     }
     try {
       assertNotDisplayed(R.color.colorAccent);
       fail();
-    } catch (BaristaArgumentTypeException expected) {
+    } catch (BaristaResourceTypeException expected) {
     }
     try {
       assertNotExist(R.color.colorAccent);
       fail();
-    } catch (BaristaArgumentTypeException expected) {
+    } catch (BaristaResourceTypeException expected) {
     }
     try {
       assertEnabled(R.color.colorAccent);
       fail();
-    } catch (BaristaArgumentTypeException expected) {
+    } catch (BaristaResourceTypeException expected) {
     }
     try {
       assertDisabled(R.color.colorAccent);
       fail();
-    } catch (BaristaArgumentTypeException expected) {
+    } catch (BaristaResourceTypeException expected) {
     }
     try {
       assertFocused(R.color.colorAccent);
       fail();
-    } catch (BaristaArgumentTypeException expected) {
+    } catch (BaristaResourceTypeException expected) {
     }
     try {
       assertNotFocused(R.color.colorAccent);
       fail();
-    } catch (BaristaArgumentTypeException expected) {
+    } catch (BaristaResourceTypeException expected) {
     }
   }
 


### PR DESCRIPTION
## TL;DR:
This method allows asserting that any view on the screen matches a certain condition, without getting the infamous Espresso error `AmbiguousViewMatcherException`.

## Rationale
We say we do magic for things like views below a scroll or duplicated views on screen. But actually that only work for some Assertions and Interactions, not all of them implement it. E.g.: https://github.com/SchibstedSpain/Barista/issues/107 https://github.com/SchibstedSpain/Barista/issues/46

## Solution
In this PR I propose to extract the assertion code to one place, and reuse it everywhere it's needed. (The same should be done for Interactions, see https://github.com/SchibstedSpain/Barista/pull/196).
I created a function to be used like this:

```kotlin
assertAnyView(withId(R.id.button), isDisplayed())
```

We don't usually expose kotlin APIs, but since this method is intended for internal usage I also added an extension function alias:
```kotlin
withId(R.id.button).assertAny(isDisplayed())
```