### PR TITLE
Made public:

### DIFF
--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaVisibilityAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaVisibilityAssertions.kt
@@ -2,11 +2,11 @@ package com.schibsted.spain.barista.assertion
 
 import android.support.annotation.ColorRes
 import android.support.annotation.IdRes
-import android.support.test.espresso.AmbiguousViewMatcherException
 import android.support.test.espresso.Espresso.onView
-import android.support.test.espresso.NoMatchingViewException
+import android.support.test.espresso.ViewAssertion
 import android.support.test.espresso.assertion.ViewAssertions.doesNotExist
 import android.support.test.espresso.assertion.ViewAssertions.matches
+import android.support.test.espresso.matcher.ViewMatchers
 import android.support.test.espresso.matcher.ViewMatchers.*
 import android.view.View
 import com.schibsted.spain.barista.internal.failurehandler.SpyFailureHandler
@@ -36,26 +36,49 @@ object BaristaVisibilityAssertions {
         onView(withId(resId)).check(matches(withText(text)))
     }
 
+
+
+
     /**
      * Attempts to find the view with multiple conditions:
      * 1. Simplest case
      * 2. More than one view
      */
-    private fun assertDisplayed(matcher: Matcher<View>) {
+    private fun assertVisibility(viewMatcher: Matcher<View>, viewAssertion: ViewAssertion, errorString: String) {
         val spyFailureHandler = SpyFailureHandler()
         try {
-            onView(matcher)
+            onView(viewMatcher)
                     .withFailureHandler(spyFailureHandler)
-                    .check(matches(isDisplayed()))
+                    .check(viewAssertion)
         } catch (firstError: RuntimeException) {
             try {
-                onView(HelperMatchers.firstViewOf(allOf(matcher, isDisplayed())))
+                onView(HelperMatchers.firstViewOf(allOf(viewMatcher)))
                         .withFailureHandler(spyFailureHandler)
-                        .check(matches(isDisplayed()))
+                        .check(viewAssertion)
             } catch (secondError: RuntimeException) {
-                spyFailureHandler.resendFirstError("View ${matcher.description()} wasn't displayed on the screen")
+                spyFailureHandler.resendFirstError("View ${viewMatcher.description()} $errorString")
             }
         }
+    }
+
+    @JvmStatic
+    fun assertDisplayed(viewMatcher: Matcher<View>) {
+        assertVisibility(viewMatcher, matches(isDisplayed()),"is NOT Displayed on the screen")
+    }
+
+    @JvmStatic
+    fun assertNotDisplayed(viewMatcher: Matcher<View>) {
+        assertVisibility(viewMatcher, matches(not(isDisplayed())), "is Displayed on the screen")
+    }
+
+    @JvmStatic
+    fun assertEffectivelyVisible(viewMatcher: Matcher<View>) {
+        assertVisibility(viewMatcher, matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)),"is not Effectively visible on the screen")
+    }
+
+    @JvmStatic
+    fun assertNotExist(viewMatcher: Matcher<View>) {
+        assertVisibility(viewMatcher, doesNotExist(),"is present in the hierarchy")
     }
 
     @JvmStatic

--- a/library/src/main/java/com/schibsted/spain/barista/interaction/BaristaClickInteractions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/interaction/BaristaClickInteractions.kt
@@ -51,6 +51,11 @@ object BaristaClickInteractions {
         performClickTypeOnMatcher(withText(text), longClick())
     }
 
+    @JvmStatic
+    fun clickOn(viewMatcher: Matcher<View>) {
+        performClickTypeOnMatcher(viewMatcher, click())
+    }
+
     private fun performClickTypeOnMatcher(viewMatcher: Matcher<View>, clickType: ViewAction) {
         val spyHandler = SpyFailureHandler()
         try {

--- a/library/src/main/java/com/schibsted/spain/barista/interaction/BaristaScrollInteractions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/interaction/BaristaScrollInteractions.kt
@@ -28,8 +28,18 @@ object BaristaScrollInteractions {
     }
 
     @JvmStatic
+    fun scrollTo(matcher: Matcher<View>) {
+        scrollWithMultipleAttempts(matcher, failAtEnd = true)
+    }
+
+    @JvmStatic
     fun scrollTo(text: String) {
         scrollWithMultipleAttempts(withText(text), failAtEnd = true)
+    }
+
+    @JvmStatic
+    fun safelyScrollTo(matcher: Matcher<View>) {
+        scrollWithMultipleAttempts(matcher, failAtEnd = false)
     }
 
     @JvmStatic


### PR DESCRIPTION
We have a lot of complex selectors. Lots of "allOf(...)" in our tests on java. So it will be very convenient to have additional public methods with matchers as argument.

Made public:
assertDisplayed(viewMatcher: Matcher<View>)
assertNotDisplayed(viewMatcher: Matcher<View>)
assertNotExist(viewMatcher: Matcher<View>)
clickOn(viewMatcher: Matcher<View>)
scrollTo(matcher: Matcher<View>)
safelyScrollTo(matcher: Matcher<View>)

Added:
assertEffectivelyVisible(viewMatcher: Matcher<View>)