### PR TITLE
Explain how to use @get:Rule in Kotlin tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,8 @@ The rule assumes some sane defaults:
 - Clear databases
 - Clear files
 
+### Writing tests in Kotlin?
+[Check this link](https://github.com/SchibstedSpain/Barista/issues/219) to know how to use `@Rule` in Kotlin.
 
 # Magic that Barista does for you
 


### PR DESCRIPTION
As soon as I saw #219 issue, I thought that the simpler way to fix it is to link it on the readme. In that issue, @FireZenk explains how to deal with `@Rule` on Kotlin, giving good examples. Right now, I think we don't need to explain how to use Barista as a `@Rule` on Kotlin, as it's used as every other `@Rule` ... but linking the issue is easy enough to be done.