### PR TITLE
Update readme with new Gradle syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ _Psst, hey. Migrating to Barista 2? [Check out this guide](MIGRATION-2.md) to he
 
 Import Barista as a testing dependency:
 ```gradle
-androidTestCompile('com.schibsted.spain:barista:2.4.0') {
+androidTestImplementation('com.schibsted.spain:barista:2.4.0') {
   exclude group: 'com.android.support'
   exclude group: 'org.jetbrains.kotlin' // Only if you already use Kotlin in your project
 }
@@ -37,7 +37,7 @@ androidTestCompile('com.schibsted.spain:barista:2.4.0') {
 You might need to include the Google Maven repository, required by Espresso 3:
 ```gradle
 repositories {
-    maven { url "https://maven.google.com" }
+    google()
 }
 ```
 


### PR DESCRIPTION
The old androidTestCompile is deprecated. We should recommend using the new androidTestImplementation.

I also updated the google repository configuration, assuming people use the 3.x Android Gradle plugin.

Fixes https://github.com/SchibstedSpain/Barista/issues/217