### PR TITLE
Added preliminar dokka config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ buildscript {
         classpath 'com.android.tools.build:gradle:3.1.3'
         classpath 'com.novoda:bintray-release:0.8.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "org.jetbrains.dokka:dokka-android-gradle-plugin:0.9.17"
     }
 }
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'com.novoda.bintray-release'
+apply plugin: 'org.jetbrains.dokka-android'
 apply from: '../config/android-quality.gradle'
 
 android {
@@ -35,6 +36,30 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:1.7.0'
     testImplementation 'org.mockito:mockito-core:2.13.0'
 }
+
+dokka {
+  outputFormat = 'javadoc'
+  outputDirectory = "$buildDir/javadoc"
+
+  packageOptions {
+    prefix = "com.schibsted.spain.barista"
+    reportUndocumented = true
+    includeNonPublic = false
+  }
+  packageOptions {
+    prefix = "com.schibsted.spain.barista.internal"
+    suppress = true
+  }
+  packageOptions {
+    prefix = "com.schibsted.spain.barista.rule.cleardata.internal"
+    suppress = true
+  }
+  packageOptions {
+    prefix = "com.schibsted.spain.barista.rule.flaky.internal"
+    suppress = true
+  }
+}
+
 
 publish {
     userOrg = 'schibstedspain'


### PR DESCRIPTION
This allows generating java or kotlin documentation with the `dokka` gradle task.
I added config to exclude our internal packages, so the documentation only reflects the public API.

It can be viewed by running the task `./gradle dokka`. The files are generated under `library/build/javadoc`. 

Now the question is: Is it useful? Do we want it? 
