### PR TITLE
Fix ListInteractions failure handling

### DIFF
--- a/library/src/main/java/com/schibsted/spain/barista/internal/failurehandler/SpyFailureHandler.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/internal/failurehandler/SpyFailureHandler.kt
@@ -5,9 +5,12 @@ import android.support.test.espresso.getFailureHandler
 import android.view.View
 import org.hamcrest.Matcher
 
-class SpyFailureHandler : FailureHandler {
+open class SpyFailureHandler : FailureHandler {
 
-    val capturedFailures: MutableList<EspressoFailure> = ArrayList()
+    val capturedFailures = mutableListOf<EspressoFailure>()
+
+    open val capturedFailuresCount: Int
+        get() = capturedFailures.size
 
     override fun handle(error: Throwable, viewMatcher: Matcher<View>) {
         capturedFailures.add(EspressoFailure(error, viewMatcher))

--- a/library/src/main/java/com/schibsted/spain/barista/internal/viewaction/ClickChildAction.java
+++ b/library/src/main/java/com/schibsted/spain/barista/internal/viewaction/ClickChildAction.java
@@ -43,7 +43,7 @@ public class ClickChildAction {
           throw new PerformException.Builder()
               .withActionDescription(getDescription())
               .withViewDescription(HumanReadables.describe(view))
-              .withCause(new RuntimeException("Didn't find any view " + HelperFunctionsKt.description(childMatcher)))
+              .withCause(new IllegalArgumentException("Didn't find any view " + HelperFunctionsKt.description(childMatcher)))
               .build();
         }
       }

--- a/library/src/main/java/com/schibsted/spain/barista/internal/viewaction/ClickChildAction.java
+++ b/library/src/main/java/com/schibsted/spain/barista/internal/viewaction/ClickChildAction.java
@@ -1,10 +1,13 @@
 package com.schibsted.spain.barista.internal.viewaction;
 
 import android.support.annotation.IdRes;
+import android.support.test.espresso.PerformException;
 import android.support.test.espresso.UiController;
 import android.support.test.espresso.ViewAction;
+import android.support.test.espresso.util.HumanReadables;
 import android.view.View;
 import android.widget.TextView;
+import com.schibsted.spain.barista.internal.failurehandler.HelperFunctionsKt;
 import com.schibsted.spain.barista.internal.util.ViewTreeAnalyzer;
 import org.hamcrest.Matcher;
 
@@ -28,13 +31,21 @@ public class ClickChildAction {
 
       @Override
       public String getDescription() {
-        return "Click on a child view " + childMatcher;
+        return "Click on a child view " + HelperFunctionsKt.description(childMatcher);
       }
 
       @Override
       public void perform(UiController uiController, View view) {
         View child = view.findViewById(childId);
-        child.performClick();
+        if (child != null) {
+          child.performClick();
+        } else {
+          throw new PerformException.Builder()
+              .withActionDescription(getDescription())
+              .withViewDescription(HumanReadables.describe(view))
+              .withCause(new RuntimeException("Didn't find any view " + HelperFunctionsKt.description(childMatcher)))
+              .build();
+        }
       }
     };
   }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -38,6 +38,8 @@ dependencies {
   androidTestImplementation "com.android.support.test.uiautomator:uiautomator-v18:$uiAutomatorVersion"
   androidTestImplementation "com.android.support.test.espresso:espresso-intents:$espressoVersion"
   androidTestImplementation "org.assertj:assertj-core:2.9.1"
+  androidTestImplementation "com.nhaarman:mockito-kotlin:1.5.0"
+  androidTestImplementation "org.mockito:mockito-android:2.16.0"
 
 
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -19,6 +19,10 @@ android {
       proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
     }
   }
+  compileOptions {
+    sourceCompatibility JavaVersion.VERSION_1_8
+    targetCompatibility JavaVersion.VERSION_1_8
+  }
 }
 
 dependencies {
@@ -29,10 +33,13 @@ dependencies {
   implementation "com.android.support:support-annotations:$supportLibVersion"
   implementation 'com.github.bumptech.glide:glide:4.7.1'
 
-  androidTestApi "com.android.support.test.espresso:espresso-core:$espressoVersion"
-  androidTestApi "com.android.support.test.espresso:espresso-contrib:$espressoVersion"
-  androidTestApi "com.android.support.test.uiautomator:uiautomator-v18:$uiAutomatorVersion"
-  androidTestApi "com.android.support.test.espresso:espresso-intents:$espressoVersion"
+  androidTestImplementation "com.android.support.test.espresso:espresso-core:$espressoVersion"
+  androidTestImplementation "com.android.support.test.espresso:espresso-contrib:$espressoVersion"
+  androidTestImplementation "com.android.support.test.uiautomator:uiautomator-v18:$uiAutomatorVersion"
+  androidTestImplementation "com.android.support.test.espresso:espresso-intents:$espressoVersion"
+  androidTestImplementation "org.assertj:assertj-core:2.9.1"
+
+
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/ListsClickTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/ListsClickTest.java
@@ -193,6 +193,36 @@ public class ListsClickTest {
             + "You must specify an id parameter using clickListItem(id, position)");
   }
 
+  @Test
+  public void fail_whenWrongRecyclerItemPosition() {
+    launchTestActivity(ListsActivity.buildIntent()
+        .withRecyclers(R.id.recycler)
+    );
+
+    Throwable thrown = catchThrowable(() -> clickListItem(999));
+
+    spyFailureHandlerRule.assertEspressoFailures(1);
+    assertThat(thrown).isInstanceOf(BaristaException.class)
+        .hasMessageContaining("Could not perform action")
+        .hasMessageContaining("performClick() on item at position: 999")
+        .hasMessageContaining("on RecyclerView")
+        .hasStackTraceContaining("No view holder at position: 999");
+  }
+
+  @Test
+  public void fail_whenWrongListViewItemPosition() {
+    launchTestActivity(ListsActivity.buildIntent()
+        .withSimpleLists(R.id.listview)
+    );
+
+    Throwable thrown = catchThrowable(() -> clickListItem(999));
+
+    spyFailureHandlerRule.assertEspressoFailures(1);
+    assertThat(thrown).isInstanceOf(BaristaException.class)
+        .hasMessageContaining("Could not perform action (Click on the view using performClick()) on ListView")
+        .hasStackTraceContaining("requested 999 element");
+  }
+
   private void assertResult(String text) {
     onView(withId(R.id.clicked_text_result)).check(matches(withText(text)));
   }

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/ListsClickTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/ListsClickTest.java
@@ -159,8 +159,8 @@ public class ListsClickTest {
 
     spyFailureHandlerRule.assertEspressoFailures(1);
     assertThat(thrown).isInstanceOf(BaristaException.class)
-        .hasMessage(
-            "There are multiple ListView or RecyclerView in the hierarchy. You must specify an id parameter using clickListItem(id, position)");
+        .hasMessage("There are multiple ListView or RecyclerView in the hierarchy."
+            + " You must specify an id parameter using clickListItem(id, position)");
   }
 
   @Test

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/util/FailureHandlerValidatorRule.kt
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/util/FailureHandlerValidatorRule.kt
@@ -7,6 +7,7 @@ import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
 
+@Deprecated("Use the more explicit [SpyFailureHandlerRule] instead")
 class FailureHandlerValidatorRule : TestRule {
 
     override fun apply(base: Statement, description: Description): Statement {

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/util/SpyFailureHandlerRule.kt
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/util/SpyFailureHandlerRule.kt
@@ -1,0 +1,32 @@
+package com.schibsted.spain.barista.sample.util
+
+import android.support.test.espresso.Espresso
+import com.schibsted.spain.barista.internal.failurehandler.SpyFailureHandler
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+
+class SpyFailureHandlerRule : TestRule {
+
+  private val failureHandler = SpyFailureHandler()
+
+  override fun apply(base: Statement, description: Description): Statement {
+
+    return object : Statement() {
+      override fun evaluate() {
+        Espresso.setFailureHandler(failureHandler)
+
+        base.evaluate()
+      }
+    }
+  }
+
+  fun assertNoEspressoFailures() {
+    assertEspressoFailures(0)
+  }
+
+  fun assertEspressoFailures(count: Int) {
+    assertThat(failureHandler.capturedFailures).hasSize(count)
+  }
+}

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/util/SpyFailureHandlerRuleTest.kt
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/util/SpyFailureHandlerRuleTest.kt
@@ -1,0 +1,60 @@
+package com.schibsted.spain.barista.sample.util
+
+import com.nhaarman.mockito_kotlin.given
+import com.nhaarman.mockito_kotlin.mock
+import com.schibsted.spain.barista.internal.failurehandler.SpyFailureHandler
+import org.junit.Test
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+
+class SpyFailureHandlerRuleTest {
+
+  val testMethod = mock<Statement>()
+  val description = mock<Description>()
+  val failureHandler = mock<SpyFailureHandler>()
+
+  val spyFailureHandlerRule = SpyFailureHandlerRule(failureHandler)
+
+  @Test(expected = AssertionError::class)
+  fun should_fail_when_nothing_asserted() {
+    // asserted = no
+    // failed = no
+    spyFailureHandlerRule.apply(testMethod, description).evaluate()
+  }
+
+  @Test(expected = RuntimeException::class)
+  fun should_rethrow_when_nothing_asserted_and_test_failed() {
+    // asserted = no
+    // failed = yes
+    given(testMethod.evaluate()).will {
+      throw RuntimeException("mocked test failed!")
+    }
+
+    spyFailureHandlerRule.apply(testMethod, description).evaluate()
+  }
+
+  @Test
+  fun should_not_fail_when_asserted_no_failures() {
+    // asserted = yes
+    // failed = no
+    given(testMethod.evaluate()).will {
+      spyFailureHandlerRule.assertNoEspressoFailures()
+    }
+
+    spyFailureHandlerRule.apply(testMethod, description).evaluate()
+  }
+
+  @Test(expected = RuntimeException::class)
+  fun should_rethrow_when_asserted_failure_and_test_failed() {
+    // asserted = yes
+    // failed = yes
+    given(failureHandler.capturedFailuresCount).willReturn(1)
+    given(testMethod.evaluate()).will {
+      spyFailureHandlerRule.assertEspressoFailures(1)
+      throw RuntimeException("mocked test failed!")
+    }
+
+    spyFailureHandlerRule.apply(testMethod, description).evaluate()
+  }
+
+}


### PR DESCRIPTION
The error handling of clickListItem and clickListItemChild were not great. This is part of https://github.com/SchibstedSpain/Barista/issues/239

Basically:
1. We were not notifying Espresso's FailureHandler when the methods fail
2. The exception messages don't provide good info about what went wrong.

I improved the tests with AssertJ's `catchThrowable()`, and a new `SpyFailureHandlerRule` similar to `FailureHandlerValidatorRule` but with less unpredictable magic.

This way we make sure that 
1. The Espresso's FailureHandler is invoked only once or never, depending on the test case.
2. The Exception message gives the information we expect, and we don't accidentally break it in the future.

PS: I added Java 8 support to the sample project, so we can use lambdas in the tests for:
```java
Throwable thrown = catchThrowable(() -> clickListItem(999));
assertThat(thrown).isInstanceOf(BaristaException.class)
    .hasMessageContaining("Could not perform action")
```
Thanks @jaumejane90 and @javiyt!