### PR TITLE
Improve assertion tests and errors

### DIFF
--- a/library/src/main/java/com/schibsted/spain/barista/internal/AssertAny.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/internal/AssertAny.kt
@@ -34,12 +34,12 @@ fun assertAnyView(viewMatcher: Matcher<View>, condition: Matcher<View>) {
             tryToAssertFirstView(viewMatcher, condition, spyFailureHandler)
         } catch (secondError: Throwable) {
             spyFailureHandler.resendFirstError(
-                "None of the views matching [${viewMatcher.description()}] did match the condition [${condition.description()}]")
+                "None of the views matching (${viewMatcher.description()}) did match the condition (${condition.description()})")
         }
     } catch (viewNotFound: NoMatchingViewException) {
-        spyFailureHandler.resendFirstError("No view matching [${viewMatcher.description()}] was found")
+        spyFailureHandler.resendFirstError("No view matching (${viewMatcher.description()}) was found")
     } catch (anotherError: Throwable) {
-        spyFailureHandler.resendFirstError("View [${viewMatcher.description()}] didn't match condition [${condition.description()}]")
+        spyFailureHandler.resendFirstError("View (${viewMatcher.description()}) didn't match condition (${condition.description()})")
     }
 }
 

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertionsTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertionsTest.java
@@ -34,7 +34,7 @@ public class AssertionsTest {
 
   @Rule
   public ActivityTestRule<SomeViewsWithDifferentVisibilitiesActivity> activityRule =
-          new ActivityTestRule<>(SomeViewsWithDifferentVisibilitiesActivity.class);
+      new ActivityTestRule<>(SomeViewsWithDifferentVisibilitiesActivity.class);
 
   @Test
   public void checkEnabledView() {
@@ -205,7 +205,7 @@ public class AssertionsTest {
     assertHasDrawable(R.id.image_view, R.drawable.ic_barista);
   }
 
-  @Test(expected = AssertionFailedError.class)
+  @Test(expected = BaristaException.class)
   public void checkDrawable_withId_failure() throws Exception {
     assertHasDrawable(R.id.image_view, R.drawable.ic_action_menu);
   }
@@ -215,7 +215,7 @@ public class AssertionsTest {
     assertHasAnyDrawable(R.id.image_view);
   }
 
-  @Test(expected = AssertionFailedError.class)
+  @Test(expected = BaristaException.class)
   public void checkDrawable_withAnyDrawable_failure() throws Exception {
     assertHasAnyDrawable(R.id.image_view_without_image);
   }
@@ -225,7 +225,7 @@ public class AssertionsTest {
     assertHasNoDrawable(R.id.image_view_without_image);
   }
 
-  @Test(expected = AssertionFailedError.class)
+  @Test(expected = BaristaException.class)
   public void checkDrawable_withoutDrawable_failure() throws Exception {
     assertHasNoDrawable(R.id.image_view);
   }
@@ -235,7 +235,7 @@ public class AssertionsTest {
     assertHasBackground(R.id.view_with_backbround, R.drawable.ic_barista);
   }
 
-  @Test(expected = AssertionFailedError.class)
+  @Test(expected = BaristaException.class)
   public void checkBackground_withId_failure() throws Exception {
     assertHasBackground(R.id.view_without_backbround, R.drawable.ic_action_menu);
   }
@@ -245,7 +245,7 @@ public class AssertionsTest {
     assertHasAnyBackground(R.id.view_with_backbround);
   }
 
-  @Test(expected = AssertionFailedError.class)
+  @Test(expected = BaristaException.class)
   public void checkBackground_withAnyDrawable_failure() throws Exception {
     assertHasAnyBackground(R.id.view_without_backbround);
   }
@@ -255,7 +255,7 @@ public class AssertionsTest {
     assertHasNoBackground(R.id.view_without_backbround);
   }
 
-  @Test(expected = AssertionFailedError.class)
+  @Test(expected = BaristaException.class)
   public void checkBackground_withoutDrawable_failure() throws Exception {
     assertHasNoBackground(R.id.view_with_backbround);
   }
@@ -279,7 +279,7 @@ public class AssertionsTest {
     assertContains(R.id.enabled_button, "Enabled");
   }
 
-  @Test(expected = AssertionFailedError.class)
+  @Test(expected = BaristaException.class)
   public void checkTextViewContainsText_withViewId_failsWhenNeeded() {
     assertContains(R.id.enabled_button, "Disabled");
   }

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertionsTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertionsTest.java
@@ -2,12 +2,9 @@ package com.schibsted.spain.barista.sample;
 
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
-
 import com.schibsted.spain.barista.internal.failurehandler.BaristaException;
 import com.schibsted.spain.barista.internal.util.BaristaResourceTypeException;
-
 import junit.framework.AssertionFailedError;
-
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -38,116 +35,6 @@ public class AssertionsTest {
   @Rule
   public ActivityTestRule<SomeViewsWithDifferentVisibilitiesActivity> activityRule =
           new ActivityTestRule<>(SomeViewsWithDifferentVisibilitiesActivity.class);
-
-  @Test
-  public void checkVisibleViews() {
-    assertDisplayed(R.id.visible_view);
-
-    assertDisplayed(R.string.hello_world);
-    assertDisplayed("Hello world!");
-  }
-
-  @Test
-  public void checkVisibleViews_breaksWhenNeeded() {
-    try {
-      assertDisplayed(R.id.invisible_view);
-      fail();
-    } catch (Throwable expected) {
-    }
-    try {
-      assertDisplayed(R.string.unknown);
-      fail();
-    } catch (Throwable expected) {
-    }
-    try {
-      assertDisplayed("Unknown");
-      fail();
-    } catch (Throwable expected) {
-    }
-  }
-
-  @Test
-  public void checkVisible_withRepeatedViews() throws Exception {
-    assertNotDisplayed(R.id.repeated_view_1_gone);
-
-    assertDisplayed("Repeated");
-    assertDisplayed(R.string.repeated);
-  }
-
-  @Test
-  public void checkExpectedText() throws Exception {
-    assertDisplayed(R.id.visible_view, "Hello world!");
-  }
-
-  @Test(expected = AssertionFailedError.class)
-  public void checkExpectedText_failsWhenTextIsNotTheExpected() throws Exception {
-    assertDisplayed(R.id.visible_view, "This is not the text you are looking for");
-  }
-
-  @Test
-  public void checkNotExpectedText() throws Exception {
-    assertNotDisplayed(R.id.visible_view, "This text must not be displayed on the view");
-  }
-
-  @Test(expected = AssertionFailedError.class)
-  public void checkNotExpectedText_failsWhenTextIsDisplayedOnTheView() throws Exception {
-    assertNotDisplayed(R.id.visible_view, "Hello world!");
-  }
-
-  @Test
-  public void checkInvisibleViews() {
-    assertNotDisplayed(R.id.invisible_view);
-    assertNotDisplayed(R.id.gone_view);
-
-    assertNotDisplayed(R.string.im_invisible);
-    assertNotDisplayed("I'm invisible!");
-  }
-
-  @Test
-  public void checkInvisibleViews_breaksWhenNeeded() {
-    try {
-      assertNotDisplayed(R.id.visible_view);
-      fail();
-    } catch (Throwable expected) {
-    }
-    try {
-      assertNotDisplayed(R.string.hello_world);
-      fail();
-    } catch (Throwable expected) {
-    }
-    try {
-      assertNotDisplayed("Hello world!");
-      fail();
-    } catch (Throwable expected) {
-    }
-  }
-
-  @Test
-  public void checkUnexistingView() {
-    assertNotExist(R.id.view_in_another_layout);
-
-    assertNotExist(R.string.unknown);
-    assertNotExist("Unknown");
-  }
-
-  @Test
-  public void checkUnexistingView_breaksWhenNeeded() {
-    try {
-      assertNotExist(R.id.visible_view);
-      fail();
-    } catch (Throwable expected) {
-    }
-    try {
-      assertNotExist(R.string.hello_world);
-      fail();
-    } catch (Throwable expected) {
-    }
-    try {
-      assertNotExist("Hello world!");
-      fail();
-    } catch (Throwable expected) {
-    }
-  }
 
   @Test
   public void checkEnabledView() {

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/ColorsTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/ColorsTest.java
@@ -2,8 +2,8 @@ package com.schibsted.spain.barista.sample;
 
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
+import com.schibsted.spain.barista.internal.failurehandler.BaristaException;
 import com.schibsted.spain.barista.sample.util.FailureHandlerValidatorRule;
-import junit.framework.AssertionFailedError;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -42,22 +42,22 @@ public class ColorsTest {
     assertTextColorIs(R.id.textSelectorChecked, R.color.checked);
   }
 
-  @Test(expected = AssertionFailedError.class)
+  @Test(expected = BaristaException.class)
   public void checkSimpleColor_fails() {
     assertTextColorIs(R.id.textRed, R.color.blue);
   }
 
-  @Test(expected = AssertionFailedError.class)
+  @Test(expected = BaristaException.class)
   public void checkColorList_whenDefault_fails() {
     assertTextColorIs(R.id.textSelectorDefault, R.color.checked);
   }
 
-  @Test(expected = AssertionFailedError.class)
+  @Test(expected = BaristaException.class)
   public void checkColorList_whenDisabled_fails() {
     assertTextColorIs(R.id.textSelectorDisabled, R.color.checked);
   }
 
-  @Test(expected = AssertionFailedError.class)
+  @Test(expected = BaristaException.class)
   public void checkColorList_whenChecked_fails() {
     assertTextColorIs(R.id.textSelectorChecked, R.color.disabled);
   }

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/ListsChildClickTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/ListsChildClickTest.java
@@ -106,7 +106,7 @@ public class ListsChildClickTest {
         .withRecyclers(R.id.recycler)
     );
 
-    Throwable thrown = catchThrowable(() -> clickListItemChild(20, R.id.unknown));
+    Throwable thrown = catchThrowable(() -> clickListItemChild(20, R.id.not_exists));
 
     spyFailureHandlerRule.assertEspressoFailures(1);
     assertThat(thrown).isInstanceOf(BaristaException.class)
@@ -122,7 +122,7 @@ public class ListsChildClickTest {
         .withComplexLists(R.id.listview)
     );
 
-    Throwable thrown = catchThrowable(() -> clickListItemChild(20, R.id.unknown));
+    Throwable thrown = catchThrowable(() -> clickListItemChild(20, R.id.not_exists));
 
     spyFailureHandlerRule.assertEspressoFailures(1);
     assertThat(thrown).isInstanceOf(BaristaException.class)

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/assertion/VisibilityAssertionsTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/assertion/VisibilityAssertionsTest.java
@@ -5,6 +5,7 @@ import android.support.test.runner.AndroidJUnit4;
 import com.schibsted.spain.barista.internal.failurehandler.BaristaException;
 import com.schibsted.spain.barista.sample.R;
 import com.schibsted.spain.barista.sample.SomeViewsWithDifferentVisibilitiesActivity;
+import com.schibsted.spain.barista.sample.util.SpyFailureHandlerRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -22,28 +23,37 @@ public class VisibilityAssertionsTest {
   public ActivityTestRule<SomeViewsWithDifferentVisibilitiesActivity> activityRule =
       new ActivityTestRule<>(SomeViewsWithDifferentVisibilitiesActivity.class);
 
+  @Rule
+  public SpyFailureHandlerRule spyFailureHandlerRule = new SpyFailureHandlerRule();
+
   public void checkDisplayedViews() {
     assertDisplayed(R.id.visible_view);
-
     assertDisplayed(R.string.hello_world);
     assertDisplayed("Hello world!");
+
+    spyFailureHandlerRule.assertNoEspressoFailures();
   }
 
   @Test
   public void checkDisplayed_withRepeatedViews() {
     assertDisplayed("Repeated");
     assertDisplayed(R.string.repeated);
+
+    spyFailureHandlerRule.assertNoEspressoFailures();
   }
 
   @Test
   public void checkNotDisplayed_withGoneView() {
     assertNotDisplayed(R.id.repeated_view_1_gone);
+
+    spyFailureHandlerRule.assertNoEspressoFailures();
   }
 
   @Test
   public void checkDisplayedViews_failsWhenInvisible() {
     Throwable thrown = catchThrowable(() -> assertDisplayed(R.id.invisible_view));
 
+    spyFailureHandlerRule.assertEspressoFailures(1);
     assertThat(thrown).isInstanceOf(BaristaException.class)
         .hasMessageContaining("invisible_view")
         .hasMessageContaining("is displayed on the screen");
@@ -53,6 +63,7 @@ public class VisibilityAssertionsTest {
   public void checkDisplayed_failsWhenNotExists() {
     Throwable thrown = catchThrowable(() -> assertDisplayed(R.string.not_exists));
 
+    spyFailureHandlerRule.assertEspressoFailures(1);
     assertThat(thrown).isInstanceOf(BaristaException.class)
         .hasMessageContaining("not_exists")
         .hasMessageContaining("No view matching");
@@ -61,12 +72,15 @@ public class VisibilityAssertionsTest {
   @Test
   public void checkDisplayedIdAndText() {
     assertDisplayed(R.id.visible_view, "Hello world!");
+
+    spyFailureHandlerRule.assertNoEspressoFailures();
   }
 
   @Test
   public void checkDisplayedIdAndText_failsWhenTextIsNotTheExpected() {
     Throwable thrown = catchThrowable(() -> assertDisplayed(R.id.visible_view, "This is not the text you are looking for"));
 
+    spyFailureHandlerRule.assertEspressoFailures(1);
     assertThat(thrown).isInstanceOf(BaristaException.class)
         .hasMessageContaining("visible_view")
         .hasMessageContaining("This is not the text you are looking for");
@@ -76,6 +90,7 @@ public class VisibilityAssertionsTest {
   public void checkDisplayedIdAndText_failsWhenViewDoesNotExist() {
     Throwable thrown = catchThrowable(() -> assertDisplayed(R.id.not_exists, "This is not the text you are looking for"));
 
+    spyFailureHandlerRule.assertEspressoFailures(1);
     assertThat(thrown).isInstanceOf(BaristaException.class)
         .hasMessageContaining("not_exists");
   }
@@ -86,17 +101,22 @@ public class VisibilityAssertionsTest {
     assertNotDisplayed(R.id.gone_view);
     assertNotDisplayed(R.string.im_invisible);
     assertNotDisplayed("I'm invisible!");
+
+    spyFailureHandlerRule.assertNoEspressoFailures();
   }
 
   @Test
   public void checkNotDisplayedIdAndText_whenTextDoesNotMatch() {
     assertNotDisplayed(R.id.visible_view, "This text must not be displayed on the view");
+
+    spyFailureHandlerRule.assertNoEspressoFailures();
   }
 
   @Test
   public void checkNotDisplayedIdAndText_failsWhenTextMatches() {
     Throwable thrown = catchThrowable(() -> assertNotDisplayed(R.id.visible_view, "Hello world!"));
 
+    spyFailureHandlerRule.assertEspressoFailures(1);
     assertThat(thrown).isInstanceOf(BaristaException.class)
         .hasMessageContaining("visible_view")
         .hasMessageContaining("not with text");
@@ -106,6 +126,7 @@ public class VisibilityAssertionsTest {
   public void checkNotDisplayed_failsWhenVisible() {
     Throwable thrown = catchThrowable(() -> assertNotDisplayed(R.id.visible_view));
 
+    spyFailureHandlerRule.assertEspressoFailures(1);
     assertThat(thrown).isInstanceOf(BaristaException.class)
         .hasMessageContaining("visible_view")
         .hasMessageContaining("not is displayed");
@@ -116,12 +137,15 @@ public class VisibilityAssertionsTest {
     assertNotExist(R.id.view_in_another_layout);
     assertNotExist(R.string.not_exists);
     assertNotExist("Unknown");
+
+    spyFailureHandlerRule.assertNoEspressoFailures();
   }
 
   @Test
   public void checkNotExist_failsWhenViewExists() {
     Throwable thrown = catchThrowable(() -> assertNotExist(R.id.visible_view));
 
+    spyFailureHandlerRule.assertEspressoFailures(1);
     assertThat(thrown).isInstanceOf(AssertionError.class)
         .hasMessageContaining("View is present in the hierarchy");
   }

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/assertion/VisibilityAssertionsTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/assertion/VisibilityAssertionsTest.java
@@ -55,8 +55,8 @@ public class VisibilityAssertionsTest {
 
     spyFailureHandlerRule.assertEspressoFailures(1);
     assertThat(thrown).isInstanceOf(BaristaException.class)
-        .hasMessageContaining("invisible_view")
-        .hasMessageContaining("is displayed on the screen");
+        .hasMessage(
+            "View (with id: com.schibsted.spain.barista.sample:id/invisible_view) didn't match condition (is displayed on the screen to the user)");
   }
 
   @Test
@@ -65,8 +65,8 @@ public class VisibilityAssertionsTest {
 
     spyFailureHandlerRule.assertEspressoFailures(1);
     assertThat(thrown).isInstanceOf(BaristaException.class)
-        .hasMessageContaining("not_exists")
-        .hasMessageContaining("No view matching");
+        .hasMessageContaining("No view matching (with string from resource id")
+        .hasMessageContaining("[not_exists] value: Not exists) was found");
   }
 
   @Test
@@ -82,8 +82,8 @@ public class VisibilityAssertionsTest {
 
     spyFailureHandlerRule.assertEspressoFailures(1);
     assertThat(thrown).isInstanceOf(BaristaException.class)
-        .hasMessageContaining("visible_view")
-        .hasMessageContaining("This is not the text you are looking for");
+        .hasMessage(
+            "View (with id: com.schibsted.spain.barista.sample:id/visible_view) didn't match condition (with text: is \"This is not the text you are looking for\")");
   }
 
   @Test
@@ -92,7 +92,7 @@ public class VisibilityAssertionsTest {
 
     spyFailureHandlerRule.assertEspressoFailures(1);
     assertThat(thrown).isInstanceOf(BaristaException.class)
-        .hasMessageContaining("not_exists");
+        .hasMessage("No view matching (with id: com.schibsted.spain.barista.sample:id/not_exists) was found");
   }
 
   @Test
@@ -118,8 +118,8 @@ public class VisibilityAssertionsTest {
 
     spyFailureHandlerRule.assertEspressoFailures(1);
     assertThat(thrown).isInstanceOf(BaristaException.class)
-        .hasMessageContaining("visible_view")
-        .hasMessageContaining("not with text");
+        .hasMessage(
+            "View (with id: com.schibsted.spain.barista.sample:id/visible_view) didn't match condition (not with text: is \"Hello world!\")");
   }
 
   @Test
@@ -128,8 +128,7 @@ public class VisibilityAssertionsTest {
 
     spyFailureHandlerRule.assertEspressoFailures(1);
     assertThat(thrown).isInstanceOf(BaristaException.class)
-        .hasMessageContaining("visible_view")
-        .hasMessageContaining("not is displayed");
+        .hasMessage("View (with id: com.schibsted.spain.barista.sample:id/visible_view) didn't match condition (not is displayed on the screen to the user)");
   }
 
   @Test

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/assertion/VisibilityAssertionsTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/assertion/VisibilityAssertionsTest.java
@@ -1,0 +1,119 @@
+package com.schibsted.spain.barista.sample.assertion;
+
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+import com.schibsted.spain.barista.internal.failurehandler.BaristaException;
+import com.schibsted.spain.barista.sample.R;
+import com.schibsted.spain.barista.sample.SomeViewsWithDifferentVisibilitiesActivity;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertDisplayed;
+import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertNotDisplayed;
+import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertNotExist;
+
+@RunWith(AndroidJUnit4.class)
+public class VisibilityAssertionsTest {
+
+  @Rule
+  public ActivityTestRule<SomeViewsWithDifferentVisibilitiesActivity> activityRule =
+      new ActivityTestRule<>(SomeViewsWithDifferentVisibilitiesActivity.class);
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void checkDisplayedViews() {
+    assertDisplayed(R.id.visible_view);
+
+    assertDisplayed(R.string.hello_world);
+    assertDisplayed("Hello world!");
+  }
+
+  @Test
+  public void checkDisplayed_withRepeatedViews() {
+    assertDisplayed("Repeated");
+    assertDisplayed(R.string.repeated);
+  }
+
+  @Test
+  public void checkNotDisplayed_withGoneView() {
+    assertNotDisplayed(R.id.repeated_view_1_gone);
+  }
+
+  @Test
+  public void checkDisplayedViews_failsWhenInvisible() {
+    thrown.expect(BaristaException.class);
+
+    assertDisplayed(R.id.invisible_view);
+  }
+
+  @Test
+  public void checkDisplayed_failsWhenNotExists() {
+    thrown.expect(BaristaException.class);
+
+    assertDisplayed(R.string.not_exists);
+  }
+
+  @Test
+  public void checkDisplayedIdAndText() {
+    assertDisplayed(R.id.visible_view, "Hello world!");
+  }
+
+  @Test
+  public void checkDisplayedIdAndText_failsWhenTextIsNotTheExpected() {
+    thrown.expect(BaristaException.class);
+
+    assertDisplayed(R.id.visible_view, "This is not the text you are looking for");
+  }
+
+  @Test
+  public void checkDisplayedIdAndText_failsWhenViewDoesNotExist() {
+    thrown.expect(BaristaException.class);
+
+    assertDisplayed(R.id.not_exists, "This is not the text you are looking for");
+  }
+
+  @Test
+  public void checkNotDisplayed_withInvisibleAndGoneViews() {
+    assertNotDisplayed(R.id.invisible_view);
+    assertNotDisplayed(R.id.gone_view);
+    assertNotDisplayed(R.string.im_invisible);
+    assertNotDisplayed("I'm invisible!");
+  }
+
+  @Test
+  public void checkNotDisplayedIdAndText_whenTextDoesNotMatch() {
+    assertNotDisplayed(R.id.visible_view, "This text must not be displayed on the view");
+  }
+
+  @Test
+  public void checkNotDisplayedIdAndText_failsWhenTextMatches() {
+    thrown.expect(BaristaException.class);
+
+    assertNotDisplayed(R.id.visible_view, "Hello world!");
+  }
+
+  @Test
+  public void checkNotDisplayed_failsWhenVisible() {
+    thrown.expect(BaristaException.class);
+
+    assertNotDisplayed(R.id.visible_view);
+  }
+
+  @Test
+  public void checkNotExist() {
+    assertNotExist(R.id.view_in_another_layout);
+    assertNotExist(R.string.not_exists);
+    assertNotExist("Unknown");
+  }
+
+  @Test
+  public void checkNotExist_failsWhenViewExists() {
+    thrown.expect(AssertionError.class);
+
+    assertNotExist(R.id.visible_view);
+  }
+}

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/assertion/VisibilityAssertionsTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/assertion/VisibilityAssertionsTest.java
@@ -7,13 +7,13 @@ import com.schibsted.spain.barista.sample.R;
 import com.schibsted.spain.barista.sample.SomeViewsWithDifferentVisibilitiesActivity;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
 import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertDisplayed;
 import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertNotDisplayed;
 import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertNotExist;
-import static org.hamcrest.Matchers.containsString;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.ThrowableAssert.catchThrowable;
 
 @RunWith(AndroidJUnit4.class)
 public class VisibilityAssertionsTest {
@@ -22,10 +22,6 @@ public class VisibilityAssertionsTest {
   public ActivityTestRule<SomeViewsWithDifferentVisibilitiesActivity> activityRule =
       new ActivityTestRule<>(SomeViewsWithDifferentVisibilitiesActivity.class);
 
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
-
-  @Test
   public void checkDisplayedViews() {
     assertDisplayed(R.id.visible_view);
 
@@ -46,20 +42,20 @@ public class VisibilityAssertionsTest {
 
   @Test
   public void checkDisplayedViews_failsWhenInvisible() {
-    thrown.expect(BaristaException.class);
-    thrown.expectMessage(containsString("invisible_view"));
-    thrown.expectMessage(containsString("is displayed on the screen"));
+    Throwable thrown = catchThrowable(() -> assertDisplayed(R.id.invisible_view));
 
-    assertDisplayed(R.id.invisible_view);
+    assertThat(thrown).isInstanceOf(BaristaException.class)
+        .hasMessageContaining("invisible_view")
+        .hasMessageContaining("is displayed on the screen");
   }
 
   @Test
   public void checkDisplayed_failsWhenNotExists() {
-    thrown.expect(BaristaException.class);
-    thrown.expectMessage(containsString("not_exists"));
-    thrown.expectMessage(containsString("No view matching"));
+    Throwable thrown = catchThrowable(() -> assertDisplayed(R.string.not_exists));
 
-    assertDisplayed(R.string.not_exists);
+    assertThat(thrown).isInstanceOf(BaristaException.class)
+        .hasMessageContaining("not_exists")
+        .hasMessageContaining("No view matching");
   }
 
   @Test
@@ -69,20 +65,19 @@ public class VisibilityAssertionsTest {
 
   @Test
   public void checkDisplayedIdAndText_failsWhenTextIsNotTheExpected() {
-    thrown.expect(BaristaException.class);
-    thrown.expectMessage(containsString("visible_view"));
-    thrown.expectMessage(containsString("This is not the text you are looking for"));
+    Throwable thrown = catchThrowable(() -> assertDisplayed(R.id.visible_view, "This is not the text you are looking for"));
 
-    assertDisplayed(R.id.visible_view, "This is not the text you are looking for");
+    assertThat(thrown).isInstanceOf(BaristaException.class)
+        .hasMessageContaining("visible_view")
+        .hasMessageContaining("This is not the text you are looking for");
   }
 
   @Test
   public void checkDisplayedIdAndText_failsWhenViewDoesNotExist() {
-    thrown.expect(BaristaException.class);
-    thrown.expectMessage(containsString("not_exists"));
-    thrown.expectMessage(containsString("No view matching"));
+    Throwable thrown = catchThrowable(() -> assertDisplayed(R.id.not_exists, "This is not the text you are looking for"));
 
-    assertDisplayed(R.id.not_exists, "This is not the text you are looking for");
+    assertThat(thrown).isInstanceOf(BaristaException.class)
+        .hasMessageContaining("not_exists");
   }
 
   @Test
@@ -100,20 +95,20 @@ public class VisibilityAssertionsTest {
 
   @Test
   public void checkNotDisplayedIdAndText_failsWhenTextMatches() {
-    thrown.expect(BaristaException.class);
-    thrown.expectMessage(containsString("visible_view"));
-    thrown.expectMessage(containsString("not with text"));
+    Throwable thrown = catchThrowable(() -> assertNotDisplayed(R.id.visible_view, "Hello world!"));
 
-    assertNotDisplayed(R.id.visible_view, "Hello world!");
+    assertThat(thrown).isInstanceOf(BaristaException.class)
+        .hasMessageContaining("visible_view")
+        .hasMessageContaining("not with text");
   }
 
   @Test
   public void checkNotDisplayed_failsWhenVisible() {
-    thrown.expect(BaristaException.class);
-    thrown.expectMessage(containsString("visible_view"));
-    thrown.expectMessage(containsString("not is displayed"));
+    Throwable thrown = catchThrowable(() -> assertNotDisplayed(R.id.visible_view));
 
-    assertNotDisplayed(R.id.visible_view);
+    assertThat(thrown).isInstanceOf(BaristaException.class)
+        .hasMessageContaining("visible_view")
+        .hasMessageContaining("not is displayed");
   }
 
   @Test
@@ -125,9 +120,9 @@ public class VisibilityAssertionsTest {
 
   @Test
   public void checkNotExist_failsWhenViewExists() {
-    thrown.expect(AssertionError.class);
-    thrown.expectMessage(containsString("View is present in the hierarchy"));
+    Throwable thrown = catchThrowable(() -> assertNotExist(R.id.visible_view));
 
-    assertNotExist(R.id.visible_view);
+    assertThat(thrown).isInstanceOf(AssertionError.class)
+        .hasMessageContaining("View is present in the hierarchy");
   }
 }

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/assertion/VisibilityAssertionsTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/assertion/VisibilityAssertionsTest.java
@@ -13,6 +13,7 @@ import org.junit.runner.RunWith;
 import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertDisplayed;
 import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertNotDisplayed;
 import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertNotExist;
+import static org.hamcrest.Matchers.containsString;
 
 @RunWith(AndroidJUnit4.class)
 public class VisibilityAssertionsTest {
@@ -46,6 +47,8 @@ public class VisibilityAssertionsTest {
   @Test
   public void checkDisplayedViews_failsWhenInvisible() {
     thrown.expect(BaristaException.class);
+    thrown.expectMessage(containsString("invisible_view"));
+    thrown.expectMessage(containsString("is displayed on the screen"));
 
     assertDisplayed(R.id.invisible_view);
   }
@@ -53,6 +56,8 @@ public class VisibilityAssertionsTest {
   @Test
   public void checkDisplayed_failsWhenNotExists() {
     thrown.expect(BaristaException.class);
+    thrown.expectMessage(containsString("not_exists"));
+    thrown.expectMessage(containsString("No view matching"));
 
     assertDisplayed(R.string.not_exists);
   }
@@ -65,6 +70,8 @@ public class VisibilityAssertionsTest {
   @Test
   public void checkDisplayedIdAndText_failsWhenTextIsNotTheExpected() {
     thrown.expect(BaristaException.class);
+    thrown.expectMessage(containsString("visible_view"));
+    thrown.expectMessage(containsString("This is not the text you are looking for"));
 
     assertDisplayed(R.id.visible_view, "This is not the text you are looking for");
   }
@@ -72,6 +79,8 @@ public class VisibilityAssertionsTest {
   @Test
   public void checkDisplayedIdAndText_failsWhenViewDoesNotExist() {
     thrown.expect(BaristaException.class);
+    thrown.expectMessage(containsString("not_exists"));
+    thrown.expectMessage(containsString("No view matching"));
 
     assertDisplayed(R.id.not_exists, "This is not the text you are looking for");
   }
@@ -92,6 +101,8 @@ public class VisibilityAssertionsTest {
   @Test
   public void checkNotDisplayedIdAndText_failsWhenTextMatches() {
     thrown.expect(BaristaException.class);
+    thrown.expectMessage(containsString("visible_view"));
+    thrown.expectMessage(containsString("not with text"));
 
     assertNotDisplayed(R.id.visible_view, "Hello world!");
   }
@@ -99,6 +110,8 @@ public class VisibilityAssertionsTest {
   @Test
   public void checkNotDisplayed_failsWhenVisible() {
     thrown.expect(BaristaException.class);
+    thrown.expectMessage(containsString("visible_view"));
+    thrown.expectMessage(containsString("not is displayed"));
 
     assertNotDisplayed(R.id.visible_view);
   }
@@ -113,6 +126,7 @@ public class VisibilityAssertionsTest {
   @Test
   public void checkNotExist_failsWhenViewExists() {
     thrown.expect(AssertionError.class);
+    thrown.expectMessage(containsString("View is present in the hierarchy"));
 
     assertNotExist(R.id.visible_view);
   }

--- a/sample/src/main/res/layout/activity_not_shown.xml
+++ b/sample/src/main/res/layout/activity_not_shown.xml
@@ -8,6 +8,6 @@
       android:id="@+id/view_in_another_layout"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      android:text="@string/unknown"/>
+      android:text="@string/not_exists"/>
 
 </LinearLayout>

--- a/sample/src/main/res/values/ids.xml
+++ b/sample/src/main/res/values/ids.xml
@@ -6,5 +6,5 @@
   <item name="recycler2" type="id" />
   <item name="gridview" type="id" />
   <item name="gridview2" type="id" />
-  <item name="unknown" type="id" />
+  <item name="not_exists" type="id" />
 </resources>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -6,7 +6,7 @@
   <string name="hello_world">Hello world!</string>
   <string name="repeated">Repeated</string>
   <string name="im_invisible">I\'m invisible!</string>
-  <string name="unknown">Unknown</string>
+  <string name="not_exists">Unknown</string>
   <string name="enabled_button">Enabled button</string>
   <string name="disabled_button">Disabled button</string>
   <string name="centered_edittext">I\'m a centered edittext!</string>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -6,7 +6,7 @@
   <string name="hello_world">Hello world!</string>
   <string name="repeated">Repeated</string>
   <string name="im_invisible">I\'m invisible!</string>
-  <string name="not_exists">Unknown</string>
+  <string name="not_exists">Not exists</string>
   <string name="enabled_button">Enabled button</string>
   <string name="disabled_button">Disabled button</string>
   <string name="centered_edittext">I\'m a centered edittext!</string>


### PR DESCRIPTION
This is the second step after https://github.com/SchibstedSpain/Barista/pull/240

I extracted the visibility assertion tests to its own class. 
I've put some order in the tests to hopefully make them easier to understand.
And I added a bunch of tests for failure scenarios, to make sure we're giving the right message to the user instead of confusing them more.

While doing so I stepped into bugs like https://github.com/SchibstedSpain/Barista/issues/220 and https://github.com/SchibstedSpain/Barista/issues/197, and fixed them directly in the `AssertAny` function.


After this I'll keep improving the tests for other assertions. But I wanted to keep this PR as short as possible.