### PR TITLE
Assert displayed with string resource

### DIFF
--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaVisibilityAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaVisibilityAssertions.kt
@@ -2,6 +2,7 @@ package com.schibsted.spain.barista.assertion
 
 import android.support.annotation.ColorRes
 import android.support.annotation.IdRes
+import android.support.annotation.StringRes
 import android.support.test.espresso.Espresso.onView
 import android.support.test.espresso.assertion.ViewAssertions.doesNotExist
 import android.support.test.espresso.matcher.ViewMatchers.*
@@ -27,6 +28,11 @@ object BaristaVisibilityAssertions {
     @JvmStatic
     fun assertDisplayed(@IdRes viewId: Int, text: String) {
         viewId.resourceMatcher().assertAny(withText(text))
+    }
+
+    @JvmStatic
+    fun assertDisplayed(@IdRes viewId: Int, @StringRes stringId: Int) {
+        viewId.resourceMatcher().assertAny(withText(stringId))
     }
 
     @JvmStatic

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/assertion/VisibilityAssertionsTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/assertion/VisibilityAssertionsTest.java
@@ -72,6 +72,7 @@ public class VisibilityAssertionsTest {
   @Test
   public void checkDisplayedIdAndText() {
     assertDisplayed(R.id.visible_view, "Hello world!");
+    assertDisplayed(R.id.visible_view, R.string.hello_world);
 
     spyFailureHandlerRule.assertNoEspressoFailures();
   }


### PR DESCRIPTION
This pull request adds the ability to assert text is displayed on a specific view with a resource string.

`fun assertDisplayed(@IdRes viewId: Int, @StringRes stringId: Int)`

This new method was tested on an instrumented test.