### PR TITLE
Add assertAny {} with sugar for kotlin

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,39 @@ assertProgressIsMax(R.id.seek_bar)
 
 ```
 
+### Barista custom assert
+
+Do your own asserts on given view, no more custom *Matcher*
+
+```kotlin
+
+assertAny<ViewType>(R.id.editText) {
+    it.text.toString() == "Hello!"
+}
+
+assertAny<ViewType>("Hello!") {
+    it.text.toString() == "Hello!"
+}
+
+assertAny<ViewType>(withId(R.id.editText)) {
+    it.text.toString() == "Hello!"
+}
+
+// With custom matcher description
+
+assertAny<ViewType>(R.id.editText, "error message") {
+    it.text.toString() == "Hello!"
+}
+
+assertAny<ViewType>("Hello!", "error message") {
+    it.text.toString() == "Hello!"
+}
+
+assertAny<ViewType>(withId(R.id.editText), "error message") {
+    it.text.toString() == "Hello!"
+}
+```
+
 ## Barista’s Intents API
 ```java
 // Creates a Bitmap on a camera provided URI

--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaAssertions.kt
@@ -3,8 +3,14 @@ package com.schibsted.spain.barista.assertion
 import android.support.test.espresso.Espresso.onView
 import android.support.test.espresso.NoActivityResumedException
 import android.support.test.espresso.action.ViewActions
+import android.support.test.espresso.matcher.ViewMatchers
 import android.support.test.espresso.matcher.ViewMatchers.isRoot
+import android.view.View
+import com.schibsted.spain.barista.internal.assertAnyView
 import com.schibsted.spain.barista.internal.failurehandler.RethrowingFailureHandler
+import com.schibsted.spain.barista.internal.matcher.BooleanMatcher
+import com.schibsted.spain.barista.internal.util.resourceMatcher
+import org.hamcrest.Matcher
 import org.junit.Assert.fail
 
 object BaristaAssertions {
@@ -21,6 +27,30 @@ object BaristaAssertions {
         } catch (noActivityException: NoActivityResumedException) {
             //Yey!
         }
+    }
+
+    /**
+     * Extension function alias for [assertAnyView]
+     */
+    @JvmStatic
+    inline fun <reified T : View> assertAny(resId: Int, message: String? = null, noinline block: (T) -> Boolean) {
+        assertAny(resId.resourceMatcher(), message, block)
+    }
+
+    /**
+     * Extension function alias for [assertAnyView]
+     */
+    @JvmStatic
+    inline fun <reified T : View> assertAny(text: String, message: String? = null, noinline block: (T) -> Boolean) {
+        assertAny(ViewMatchers.withText(text), message, block)
+    }
+
+    /**
+     * Extension function alias for [assertAnyView]
+     */
+    @JvmStatic
+    inline fun <reified T : View> assertAny(matcher: Matcher<View>, message: String? = null, noinline block: (T) -> Boolean) {
+        assertAnyView(viewMatcher = matcher, condition = BooleanMatcher(message, block) as Matcher<View>)
     }
 
 }

--- a/library/src/main/java/com/schibsted/spain/barista/internal/AssertAny.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/internal/AssertAny.kt
@@ -24,22 +24,22 @@ fun Matcher<View>.assertAny(condition: Matcher<View>) {
 /**
  * Extension function alias for [assertAnyView]
  */
-inline fun <reified T: View> assertAny(resId: Int, noinline block: (T) -> Boolean) {
-    assertAny(resId.resourceMatcher(), block)
+inline fun <reified T: View> assertAny(resId: Int, message: String? = null, noinline block: (T) -> Boolean) {
+    assertAny(resId.resourceMatcher(), message, block)
 }
 
 /**
  * Extension function alias for [assertAnyView]
  */
-inline fun <reified T: View> assertAny(text: String, noinline block: (T) -> Boolean) {
-    assertAny(withText(text), block)
+inline fun <reified T: View> assertAny(text: String, message: String? = null, noinline block: (T) -> Boolean) {
+    assertAny(withText(text), message, block)
 }
 
 /**
  * Extension function alias for [assertAnyView]
  */
-inline fun <reified T: View> assertAny(matcher: Matcher<View>, noinline block: (T) -> Boolean) {
-    assertAnyView(viewMatcher = matcher, condition = BooleanMatcher(block) as Matcher<View>)
+inline fun <reified T: View> assertAny(matcher: Matcher<View>, message: String? = null, noinline block: (T) -> Boolean) {
+    assertAnyView(viewMatcher = matcher, condition = BooleanMatcher(message, block) as Matcher<View>)
 }
 
 /**

--- a/library/src/main/java/com/schibsted/spain/barista/internal/AssertAny.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/internal/AssertAny.kt
@@ -25,13 +25,21 @@ fun Matcher<View>.assertAny(condition: Matcher<View>) {
  * Extension function alias for [assertAnyView]
  */
 inline fun <reified T: View> assertAny(resId: Int, noinline block: (T) -> Boolean) {
-    assertAnyView(viewMatcher = resId.resourceMatcher(), condition = BooleanMatcher(block) as Matcher<View>)
+    assertAny(resId.resourceMatcher(), block)
 }
+
 /**
  * Extension function alias for [assertAnyView]
  */
 inline fun <reified T: View> assertAny(text: String, noinline block: (T) -> Boolean) {
-    assertAnyView(viewMatcher = withText(text), condition = BooleanMatcher(block) as Matcher<View>)
+    assertAny(withText(text), block)
+}
+
+/**
+ * Extension function alias for [assertAnyView]
+ */
+inline fun <reified T: View> assertAny(matcher: Matcher<View>, noinline block: (T) -> Boolean) {
+    assertAnyView(viewMatcher = matcher, condition = BooleanMatcher(block) as Matcher<View>)
 }
 
 /**

--- a/library/src/main/java/com/schibsted/spain/barista/internal/AssertAny.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/internal/AssertAny.kt
@@ -4,13 +4,10 @@ import android.support.test.espresso.AmbiguousViewMatcherException
 import android.support.test.espresso.Espresso.onView
 import android.support.test.espresso.NoMatchingViewException
 import android.support.test.espresso.assertion.ViewAssertions
-import android.support.test.espresso.matcher.ViewMatchers.withText
 import android.view.View
 import com.schibsted.spain.barista.internal.failurehandler.SpyFailureHandler
 import com.schibsted.spain.barista.internal.failurehandler.description
-import com.schibsted.spain.barista.internal.matcher.BooleanMatcher
 import com.schibsted.spain.barista.internal.matcher.HelperMatchers.firstViewOf
-import com.schibsted.spain.barista.internal.util.resourceMatcher
 import org.hamcrest.Matcher
 import org.hamcrest.Matchers.allOf
 
@@ -19,27 +16,6 @@ import org.hamcrest.Matchers.allOf
  */
 fun Matcher<View>.assertAny(condition: Matcher<View>) {
     assertAnyView(viewMatcher = this, condition = condition)
-}
-
-/**
- * Extension function alias for [assertAnyView]
- */
-inline fun <reified T: View> assertAny(resId: Int, message: String? = null, noinline block: (T) -> Boolean) {
-    assertAny(resId.resourceMatcher(), message, block)
-}
-
-/**
- * Extension function alias for [assertAnyView]
- */
-inline fun <reified T: View> assertAny(text: String, message: String? = null, noinline block: (T) -> Boolean) {
-    assertAny(withText(text), message, block)
-}
-
-/**
- * Extension function alias for [assertAnyView]
- */
-inline fun <reified T: View> assertAny(matcher: Matcher<View>, message: String? = null, noinline block: (T) -> Boolean) {
-    assertAnyView(viewMatcher = matcher, condition = BooleanMatcher(message, block) as Matcher<View>)
 }
 
 /**

--- a/library/src/main/java/com/schibsted/spain/barista/internal/AssertAny.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/internal/AssertAny.kt
@@ -4,10 +4,13 @@ import android.support.test.espresso.AmbiguousViewMatcherException
 import android.support.test.espresso.Espresso.onView
 import android.support.test.espresso.NoMatchingViewException
 import android.support.test.espresso.assertion.ViewAssertions
+import android.support.test.espresso.matcher.ViewMatchers.withText
 import android.view.View
 import com.schibsted.spain.barista.internal.failurehandler.SpyFailureHandler
 import com.schibsted.spain.barista.internal.failurehandler.description
+import com.schibsted.spain.barista.internal.matcher.BooleanMatcher
 import com.schibsted.spain.barista.internal.matcher.HelperMatchers.firstViewOf
+import com.schibsted.spain.barista.internal.util.resourceMatcher
 import org.hamcrest.Matcher
 import org.hamcrest.Matchers.allOf
 
@@ -16,6 +19,19 @@ import org.hamcrest.Matchers.allOf
  */
 fun Matcher<View>.assertAny(condition: Matcher<View>) {
     assertAnyView(viewMatcher = this, condition = condition)
+}
+
+/**
+ * Extension function alias for [assertAnyView]
+ */
+inline fun <reified T: View> assertAny(resId: Int, noinline block: (T) -> Boolean) {
+    assertAnyView(viewMatcher = resId.resourceMatcher(), condition = BooleanMatcher(block) as Matcher<View>)
+}
+/**
+ * Extension function alias for [assertAnyView]
+ */
+inline fun <reified T: View> assertAny(text: String, noinline block: (T) -> Boolean) {
+    assertAnyView(viewMatcher = withText(text), condition = BooleanMatcher(block) as Matcher<View>)
 }
 
 /**

--- a/library/src/main/java/com/schibsted/spain/barista/internal/matcher/BooleanMatcher.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/internal/matcher/BooleanMatcher.kt
@@ -1,0 +1,13 @@
+package com.schibsted.spain.barista.internal.matcher
+
+import android.view.View
+import org.hamcrest.Description
+import org.hamcrest.TypeSafeMatcher
+
+class BooleanMatcher<T : View>(private val block: (T) -> Boolean) : TypeSafeMatcher<T>() {
+    override fun describeTo(description: Description) {
+        description.appendText(this::class.java.name).appendText(" not matches")
+    }
+
+    override fun matchesSafely(item: T): Boolean = (item as? T)?.let(block) ?: false
+}

--- a/library/src/main/java/com/schibsted/spain/barista/internal/matcher/BooleanMatcher.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/internal/matcher/BooleanMatcher.kt
@@ -6,7 +6,7 @@ import org.hamcrest.TypeSafeMatcher
 
 class BooleanMatcher<T : View>(private val block: (T) -> Boolean) : TypeSafeMatcher<T>() {
     override fun describeTo(description: Description) {
-        description.appendText(this::class.java.name).appendText(" matches provided condition")
+        description.appendText(" matches provided condition")
     }
 
     override fun matchesSafely(item: T): Boolean = (item as? T)?.let(block) ?: false

--- a/library/src/main/java/com/schibsted/spain/barista/internal/matcher/BooleanMatcher.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/internal/matcher/BooleanMatcher.kt
@@ -11,7 +11,7 @@ class BooleanMatcher<T : View>(
     override fun describeTo(description: Description) {
         message?.let {
             description.appendText(message)
-        } ?: description.appendText("custom condition")
+        } ?: description.appendText("custom condition [use `message` parameter on `assertAny` to setup descriptive message]")
     }
 
     override fun matchesSafely(item: T): Boolean = (item as? T)?.let(block) ?: false

--- a/library/src/main/java/com/schibsted/spain/barista/internal/matcher/BooleanMatcher.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/internal/matcher/BooleanMatcher.kt
@@ -11,7 +11,7 @@ class BooleanMatcher<T : View>(
     override fun describeTo(description: Description) {
         message?.let {
             description.appendText(message)
-        } ?: description.appendText(" (custom condition)")
+        } ?: description.appendText("custom condition")
     }
 
     override fun matchesSafely(item: T): Boolean = (item as? T)?.let(block) ?: false

--- a/library/src/main/java/com/schibsted/spain/barista/internal/matcher/BooleanMatcher.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/internal/matcher/BooleanMatcher.kt
@@ -6,7 +6,7 @@ import org.hamcrest.TypeSafeMatcher
 
 class BooleanMatcher<T : View>(private val block: (T) -> Boolean) : TypeSafeMatcher<T>() {
     override fun describeTo(description: Description) {
-        description.appendText(this::class.java.name).appendText(" not matches")
+        description.appendText(this::class.java.name).appendText(" matches provided condition")
     }
 
     override fun matchesSafely(item: T): Boolean = (item as? T)?.let(block) ?: false

--- a/library/src/main/java/com/schibsted/spain/barista/internal/matcher/BooleanMatcher.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/internal/matcher/BooleanMatcher.kt
@@ -4,9 +4,14 @@ import android.view.View
 import org.hamcrest.Description
 import org.hamcrest.TypeSafeMatcher
 
-class BooleanMatcher<T : View>(private val block: (T) -> Boolean) : TypeSafeMatcher<T>() {
+class BooleanMatcher<T : View>(
+        private val message: String? = null,
+        private val block: (T) -> Boolean
+) : TypeSafeMatcher<T>() {
     override fun describeTo(description: Description) {
-        description.appendText(" matches provided condition")
+        message?.let {
+            description.appendText(message)
+        } ?: description.appendText(" (custom condition)")
     }
 
     override fun matchesSafely(item: T): Boolean = (item as? T)?.let(block) ?: false

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertAnyTest.kt
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertAnyTest.kt
@@ -3,8 +3,10 @@ package com.schibsted.spain.barista.sample
 import android.support.test.rule.ActivityTestRule
 import android.support.test.runner.AndroidJUnit4
 import android.widget.EditText
+import android.widget.ImageView
 import com.schibsted.spain.barista.interaction.BaristaEditTextInteractions.writeTo
 import com.schibsted.spain.barista.internal.assertAny
+import com.schibsted.spain.barista.internal.failurehandler.BaristaException
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -25,5 +27,12 @@ class AssertAnyTest {
         assertAny<EditText>("Hello!") {
             it.text.toString() == "Hello!"
         }
+    }
+
+    @Test(expected = BaristaException::class)
+    fun checkNoMatchesWriteOnEditText_whenAssertOnDifferentTypeOfView() {
+        writeTo(R.id.edittext, "Hello!")
+
+        assertAny<ImageView>(R.id.edittext) { true }
     }
 }

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertAnyTest.kt
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertAnyTest.kt
@@ -1,0 +1,29 @@
+package com.schibsted.spain.barista.sample
+
+import android.support.test.rule.ActivityTestRule
+import android.support.test.runner.AndroidJUnit4
+import android.widget.EditText
+import com.schibsted.spain.barista.interaction.BaristaEditTextInteractions.writeTo
+import com.schibsted.spain.barista.internal.assertAny
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class AssertAnyTest {
+
+    @get:Rule
+    var activityRule = ActivityTestRule(EditTextActivity::class.java)
+
+    @Test
+    fun checkWriteOnEditText_whenEditTextIsVisible() {
+        writeTo(R.id.edittext, "Hello!")
+
+        assertAny<EditText>(R.id.edittext) {
+            it.text.toString() == "Hello!"
+        }
+        assertAny<EditText>("Hello!") {
+            it.text.toString() == "Hello!"
+        }
+    }
+}

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertAnyTest.kt
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertAnyTest.kt
@@ -64,6 +64,20 @@ class AssertAnyTest {
         writeTo(R.id.edittext, "Hello!")
 
         assertThat(thrown).isInstanceOf(BaristaException::class.java)
-                .hasMessageContaining("matches provided condition")
+                .hasMessageContaining("didn't match condition")
+                .hasMessageContaining("(custom condition)")
+    }
+
+    @Test
+    fun checkNoMatchesWriteOnEditText_whenAssertOnDifferentTypeOfView_customMessage() {
+        val thrown = catchThrowable { assertAny<ImageView>(R.id.edittext, "Not an ImageView") { true } }
+
+        spyFailureHandlerRule.assertEspressoFailures(1)
+
+        writeTo(R.id.edittext, "Hello!")
+
+        assertThat(thrown).isInstanceOf(BaristaException::class.java)
+                .hasMessageContaining("didn't match condition")
+                .hasMessageContaining("Not an ImageView")
     }
 }

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertAnyTest.kt
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertAnyTest.kt
@@ -1,5 +1,6 @@
 package com.schibsted.spain.barista.sample
 
+import android.support.test.espresso.matcher.ViewMatchers.withId
 import android.support.test.rule.ActivityTestRule
 import android.support.test.runner.AndroidJUnit4
 import android.widget.EditText
@@ -18,13 +19,28 @@ class AssertAnyTest {
     var activityRule = ActivityTestRule(EditTextActivity::class.java)
 
     @Test
-    fun checkWriteOnEditText_whenEditTextIsVisible() {
+    fun checkWriteOnEditText_whenEditTextIsVisible_id() {
         writeTo(R.id.edittext, "Hello!")
 
         assertAny<EditText>(R.id.edittext) {
             it.text.toString() == "Hello!"
         }
+    }
+
+    @Test
+    fun checkWriteOnEditText_whenEditTextIsVisible_text() {
+        writeTo(R.id.edittext, "Hello!")
+
         assertAny<EditText>("Hello!") {
+            it.text.toString() == "Hello!"
+        }
+    }
+
+    @Test
+    fun checkWriteOnEditText_whenEditTextIsVisible_matcher() {
+        writeTo(R.id.edittext, "Hello!")
+
+        assertAny<EditText>(withId(R.id.edittext)) {
             it.text.toString() == "Hello!"
         }
     }

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertAnyTest.kt
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertAnyTest.kt
@@ -85,13 +85,13 @@ class AssertAnyTest {
 
     @Test
     fun assertAny_with_wrong_view_cast_error_custom_message() {
-        val thrown = catchThrowable { assertAny<ImageView>(R.id.edittext, "Not an ImageView") { true } }
+        val thrown = catchThrowable { assertAny<ImageView>(R.id.edittext, "is an ImageView") { true } }
 
         spyFailureHandlerRule.assertEspressoFailures(1)
 
         writeTo(R.id.edittext, "Hello!")
 
         assertThat(thrown).isInstanceOf(BaristaException::class.java)
-                .hasMessageContaining("didn't match condition (Not an ImageView)")
+                .hasMessageContaining("didn't match condition (is an ImageView)")
     }
 }

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertAnyTest.kt
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertAnyTest.kt
@@ -26,7 +26,7 @@ class AssertAnyTest {
     var spyFailureHandlerRule = SpyFailureHandlerRule()
 
     @Test
-    fun checkWriteOnEditText_whenEditTextIsVisible_id() {
+    fun assertAny_with_idMatcher() {
         spyFailureHandlerRule.assertNoEspressoFailures()
         writeTo(R.id.edittext, "Hello!")
 
@@ -36,7 +36,24 @@ class AssertAnyTest {
     }
 
     @Test
-    fun checkWriteOnEditText_whenEditTextIsVisible_text() {
+    fun assertAny_with_valid_cast_custom_error() {
+        val thrown = catchThrowable {
+            assertAny<EditText>(R.id.edittext, "String is not the same") {
+                it.text.toString() == "Hello"
+            }
+        }
+
+        spyFailureHandlerRule.assertEspressoFailures(1)
+
+        writeTo(R.id.edittext, "Hello!")
+
+        assertThat(thrown).isInstanceOf(BaristaException::class.java)
+                .hasMessageContaining("didn't match condition")
+                .hasMessageContaining("String is not the same")
+    }
+
+    @Test
+    fun assertAny_with_textMatcher() {
         spyFailureHandlerRule.assertNoEspressoFailures()
         writeTo(R.id.edittext, "Hello!")
 
@@ -46,7 +63,7 @@ class AssertAnyTest {
     }
 
     @Test
-    fun checkWriteOnEditText_whenEditTextIsVisible_matcher() {
+    fun assertAny_with_MatcherCustom() {
         spyFailureHandlerRule.assertNoEspressoFailures()
         writeTo(R.id.edittext, "Hello!")
 
@@ -56,7 +73,7 @@ class AssertAnyTest {
     }
 
     @Test
-    fun checkNoMatchesWriteOnEditText_whenAssertOnDifferentTypeOfView() {
+    fun assertAny_with_wrong_view_cast_error_default_message() {
         val thrown = catchThrowable { assertAny<ImageView>(R.id.edittext) { true } }
 
         spyFailureHandlerRule.assertEspressoFailures(1)
@@ -69,7 +86,7 @@ class AssertAnyTest {
     }
 
     @Test
-    fun checkNoMatchesWriteOnEditText_whenAssertOnDifferentTypeOfView_customMessage() {
+    fun assertAny_with_wrong_view_cast_error_custom_message() {
         val thrown = catchThrowable { assertAny<ImageView>(R.id.edittext, "Not an ImageView") { true } }
 
         spyFailureHandlerRule.assertEspressoFailures(1)

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertAnyTest.kt
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertAnyTest.kt
@@ -5,8 +5,8 @@ import android.support.test.rule.ActivityTestRule
 import android.support.test.runner.AndroidJUnit4
 import android.widget.EditText
 import android.widget.ImageView
+import com.schibsted.spain.barista.assertion.BaristaAssertions.assertAny
 import com.schibsted.spain.barista.interaction.BaristaEditTextInteractions.writeTo
-import com.schibsted.spain.barista.internal.assertAny
 import com.schibsted.spain.barista.internal.failurehandler.BaristaException
 import com.schibsted.spain.barista.sample.util.SpyFailureHandlerRule
 import org.assertj.core.api.Assertions.assertThat

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertAnyTest.kt
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertAnyTest.kt
@@ -48,8 +48,7 @@ class AssertAnyTest {
         writeTo(R.id.edittext, "Hello!")
 
         assertThat(thrown).isInstanceOf(BaristaException::class.java)
-                .hasMessageContaining("didn't match condition")
-                .hasMessageContaining("String is not the same")
+                .hasMessageContaining("didn't match condition (String is not the same)")
     }
 
     @Test
@@ -81,8 +80,7 @@ class AssertAnyTest {
         writeTo(R.id.edittext, "Hello!")
 
         assertThat(thrown).isInstanceOf(BaristaException::class.java)
-                .hasMessageContaining("didn't match condition")
-                .hasMessageContaining("(custom condition)")
+                .hasMessageContaining("didn't match condition (custom condition)")
     }
 
     @Test
@@ -94,7 +92,6 @@ class AssertAnyTest {
         writeTo(R.id.edittext, "Hello!")
 
         assertThat(thrown).isInstanceOf(BaristaException::class.java)
-                .hasMessageContaining("didn't match condition")
-                .hasMessageContaining("Not an ImageView")
+                .hasMessageContaining("didn't match condition (Not an ImageView)")
     }
 }

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertAnyTest.kt
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertAnyTest.kt
@@ -8,9 +8,13 @@ import android.widget.ImageView
 import com.schibsted.spain.barista.interaction.BaristaEditTextInteractions.writeTo
 import com.schibsted.spain.barista.internal.assertAny
 import com.schibsted.spain.barista.internal.failurehandler.BaristaException
+import com.schibsted.spain.barista.sample.util.SpyFailureHandlerRule
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.ThrowableAssert.catchThrowable
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+
 
 @RunWith(AndroidJUnit4::class)
 class AssertAnyTest {
@@ -18,8 +22,12 @@ class AssertAnyTest {
     @get:Rule
     var activityRule = ActivityTestRule(EditTextActivity::class.java)
 
+    @get:Rule
+    var spyFailureHandlerRule = SpyFailureHandlerRule()
+
     @Test
     fun checkWriteOnEditText_whenEditTextIsVisible_id() {
+        spyFailureHandlerRule.assertNoEspressoFailures()
         writeTo(R.id.edittext, "Hello!")
 
         assertAny<EditText>(R.id.edittext) {
@@ -29,6 +37,7 @@ class AssertAnyTest {
 
     @Test
     fun checkWriteOnEditText_whenEditTextIsVisible_text() {
+        spyFailureHandlerRule.assertNoEspressoFailures()
         writeTo(R.id.edittext, "Hello!")
 
         assertAny<EditText>("Hello!") {
@@ -38,6 +47,7 @@ class AssertAnyTest {
 
     @Test
     fun checkWriteOnEditText_whenEditTextIsVisible_matcher() {
+        spyFailureHandlerRule.assertNoEspressoFailures()
         writeTo(R.id.edittext, "Hello!")
 
         assertAny<EditText>(withId(R.id.edittext)) {
@@ -45,10 +55,15 @@ class AssertAnyTest {
         }
     }
 
-    @Test(expected = BaristaException::class)
+    @Test
     fun checkNoMatchesWriteOnEditText_whenAssertOnDifferentTypeOfView() {
+        val thrown = catchThrowable { assertAny<ImageView>(R.id.edittext) { true } }
+
+        spyFailureHandlerRule.assertEspressoFailures(1)
+
         writeTo(R.id.edittext, "Hello!")
 
-        assertAny<ImageView>(R.id.edittext) { true }
+        assertThat(thrown).isInstanceOf(BaristaException::class.java)
+                .hasMessageContaining("matches provided condition")
     }
 }

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertAnyTest.kt
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertAnyTest.kt
@@ -80,7 +80,7 @@ class AssertAnyTest {
         writeTo(R.id.edittext, "Hello!")
 
         assertThat(thrown).isInstanceOf(BaristaException::class.java)
-                .hasMessageContaining("didn't match condition (custom condition)")
+                .hasMessageContaining("didn't match condition (custom condition [use `message` parameter on `assertAny` to setup descriptive message])")
     }
 
     @Test


### PR DESCRIPTION
```kotlin
assertAny<EditText>(R.id.edittext) {
        it.text.toString() == "Hello!"
}
```

Now, we can use this new `assertAny` method in kotlin, and inside the lambda, return a `boolean`:D

This method(s) will help to create custom assert for any view without know how to build *matchers* 