### PR TITLE
Rename custom assertion `message` parameter to better explain its intention

### DIFF
--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaAssertions.kt
@@ -33,24 +33,24 @@ object BaristaAssertions {
      * Extension function alias for [assertAnyView]
      */
     @JvmStatic
-    inline fun <reified T : View> assertAny(resId: Int, message: String? = null, noinline block: (T) -> Boolean) {
-        assertAny(resId.resourceMatcher(), message, block)
+    inline fun <reified T : View> assertAny(resId: Int, assertionErrorMessage: String? = null, noinline block: (T) -> Boolean) {
+        assertAny(resId.resourceMatcher(), assertionErrorMessage, block)
     }
 
     /**
      * Extension function alias for [assertAnyView]
      */
     @JvmStatic
-    inline fun <reified T : View> assertAny(text: String, message: String? = null, noinline block: (T) -> Boolean) {
-        assertAny(ViewMatchers.withText(text), message, block)
+    inline fun <reified T : View> assertAny(text: String, assertionErrorMessage: String? = null, noinline block: (T) -> Boolean) {
+        assertAny(ViewMatchers.withText(text), assertionErrorMessage, block)
     }
 
     /**
      * Extension function alias for [assertAnyView]
      */
     @JvmStatic
-    inline fun <reified T : View> assertAny(matcher: Matcher<View>, message: String? = null, noinline block: (T) -> Boolean) {
-        assertAnyView(viewMatcher = matcher, condition = BooleanMatcher(message, block) as Matcher<View>)
+    inline fun <reified T : View> assertAny(matcher: Matcher<View>, assertionErrorMessage: String? = null, noinline block: (T) -> Boolean) {
+        assertAnyView(viewMatcher = matcher, condition = BooleanMatcher(assertionErrorMessage, block) as Matcher<View>)
     }
 
 }

--- a/library/src/main/java/com/schibsted/spain/barista/internal/matcher/BooleanMatcher.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/internal/matcher/BooleanMatcher.kt
@@ -11,7 +11,7 @@ class BooleanMatcher<T : View>(
     override fun describeTo(description: Description) {
         message?.let {
             description.appendText(message)
-        } ?: description.appendText("custom condition [use `message` parameter on `assertAny` to setup descriptive message]")
+        } ?: description.appendText("custom condition [use `assertionErrorMessage` parameter on `assertAny` to setup descriptive message]")
     }
 
     override fun matchesSafely(item: T): Boolean = (item as? T)?.let(block) ?: false

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertAnyTest.kt
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertAnyTest.kt
@@ -80,7 +80,7 @@ class AssertAnyTest {
         writeTo(R.id.edittext, "Hello!")
 
         assertThat(thrown).isInstanceOf(BaristaException::class.java)
-                .hasMessageContaining("didn't match condition (custom condition [use `message` parameter on `assertAny` to setup descriptive message])")
+                .hasMessageContaining("didn't match condition (custom condition [use `assertionErrorMessage` parameter on `assertAny` to setup descriptive message])")
     }
 
     @Test


### PR DESCRIPTION
I misunderstood the purpose of the `message` parameter when reading the implementation of #254, so here's a rename to make the parameter autoexplainative.