### PR TITLE
Clarify how to use the custom assertions message

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,9 +261,6 @@ assertAny<Progressbar>(withId(R.id.progressBar)) {
 assertAny<RadioGroup>(R.id.radioGroup, "selected option is the second one") {
     it.checkedRadioButtonId == R.id.option1
 }
-assertAny<Progressbar>(withId(R.id.progressBar, "progress is 42")) {
-    it.progress == 42
-}
 ```
 
 ## Barista’s Intents API

--- a/README.md
+++ b/README.md
@@ -257,9 +257,12 @@ assertAny<Progressbar>(withId(R.id.progressBar)) {
     it.progress == 42
 }
 
-// You can also define the assertion error message that will be shown if the assertion fails
-assertAny<TextView>(R.id.textView, "text wasn't Hello!") {
-    it.text.toString() == "Hello!"
+// You can also define the assertion description that will be shown if the assertion fails
+assertAny<RadioGroup>(R.id.radioGroup, "selected option is the second one") {
+    it.checkedRadioButtonId == R.id.option1
+}
+assertAny<Progressbar>(withId(R.id.progressBar, "progress is 42")) {
+    it.progress == 42
 }
 ```
 


### PR DESCRIPTION
As @Sloy explained at #255, the agreed readme could be improved. This PR does it.

Now, the project's readme will explain the custom assertion message feature by example.