### PR TITLE
Add method for custom visibility matchers

### DIFF
--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaVisibilityAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaVisibilityAssertions.kt
@@ -5,15 +5,24 @@ import android.support.annotation.IdRes
 import android.support.annotation.StringRes
 import android.support.test.espresso.Espresso.onView
 import android.support.test.espresso.assertion.ViewAssertions.doesNotExist
-import android.support.test.espresso.matcher.ViewMatchers.*
+import android.support.test.espresso.matcher.ViewMatchers.isDisplayed
+import android.support.test.espresso.matcher.ViewMatchers.withId
+import android.support.test.espresso.matcher.ViewMatchers.withText
+import android.view.View
 import com.schibsted.spain.barista.internal.assertAny
 import com.schibsted.spain.barista.internal.matcher.TextColorMatcher
 import com.schibsted.spain.barista.internal.util.resourceMatcher
 import org.hamcrest.CoreMatchers.containsString
+import org.hamcrest.Matcher
 import org.hamcrest.Matchers.allOf
 import org.hamcrest.Matchers.not
 
 object BaristaVisibilityAssertions {
+
+    @JvmStatic
+    fun assertDisplayed(viewMatcher: Matcher<View>) {
+        viewMatcher.assertAny(isDisplayed())
+    }
 
     @JvmStatic
     fun assertDisplayed(viewId: Int) {
@@ -54,6 +63,12 @@ object BaristaVisibilityAssertions {
     fun assertNotDisplayed(text: String) {
         withText(text).assertAny(not(isDisplayed()))
     }
+
+    @JvmStatic
+    fun assertNotDisplayed(viewMatcher: Matcher<View>) {
+        viewMatcher.assertAny(not(isDisplayed()))
+    }
+
 
     @JvmStatic
     fun assertNotDisplayed(@IdRes viewId: Int, text: String) {

--- a/library/src/main/java/com/schibsted/spain/barista/matchers/BaristaMatchers.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/matchers/BaristaMatchers.kt
@@ -1,0 +1,14 @@
+package com.schibsted.spain.barista.matchers
+
+import android.support.test.espresso.matcher.ViewMatchers
+import android.view.View
+import org.hamcrest.CoreMatchers
+import org.hamcrest.Matcher
+
+object BaristaMatchers {
+
+  fun tag(tagValue: String): Matcher<View> {
+    return ViewMatchers.withTagValue(CoreMatchers.`is`(tagValue))
+  }
+
+}

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/assertion/TagAssertionsTest.kt
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/assertion/TagAssertionsTest.kt
@@ -1,0 +1,54 @@
+package com.schibsted.spain.barista.sample.assertion
+
+import android.support.test.rule.ActivityTestRule
+import android.support.test.runner.AndroidJUnit4
+import com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertDisplayed
+import com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertNotDisplayed
+import com.schibsted.spain.barista.matchers.BaristaMatchers.tag
+import com.schibsted.spain.barista.sample.SomeViewsWithDifferentVisibilitiesActivity
+import org.junit.Assert.fail
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class TagAssertionsTest {
+
+  @Rule
+  @JvmField
+  var activityRule =
+      ActivityTestRule(SomeViewsWithDifferentVisibilitiesActivity::class.java)
+
+  @Test
+  fun tag_name_visible_should_be_displayed() {
+    assertDisplayed(tag("visible"))
+  }
+
+
+  @Test
+  fun tag_name_invisible_should_not_be_displayed() {
+    assertNotDisplayed(tag("invisible"))
+  }
+
+  @Test
+  fun tag_name_visible_should_fail_when_asserting_not_displayed() {
+    try {
+      assertNotDisplayed(tag("visible"))
+      fail()
+    } catch (expected: Throwable) {
+
+    }
+  }
+
+  @Test
+  fun tag_name_invisible_should_fail_when_asserting_displayed() {
+    try {
+      assertNotDisplayed(tag("visible"))
+      fail()
+    } catch (expected: Throwable) {
+
+    }
+  }
+
+
+}

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -8,12 +8,14 @@
       android:id="@+id/visible_view"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
+      android:tag="visible"
       android:text="@string/hello_world"/>
   <TextView
       android:id="@+id/repeated_view_1_gone"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:visibility="gone"
+      android:tag="invisible"
       android:text="@string/repeated"
       />
   <TextView


### PR DESCRIPTION
Related to https://github.com/SchibstedSpain/Barista/issues/224

This PR extends BaristaVisibilityAssertions class to allow users provide it's custom matchers.

It also adds a CustomMatcher wrapper to find views with a Tag