### PR TITLE
Fix assertListItemCount not throwing error when failed bug

### DIFF
--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaListAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaListAssertions.kt
@@ -12,6 +12,7 @@ import com.schibsted.spain.barista.interaction.BaristaListInteractions.findListV
 import com.schibsted.spain.barista.interaction.BaristaListInteractions.findRecyclerMatcher
 import com.schibsted.spain.barista.interaction.BaristaListInteractions.scrollListToPosition
 import com.schibsted.spain.barista.internal.failurehandler.SpyFailureHandler
+import com.schibsted.spain.barista.internal.failurehandler.withFailureHandler
 import com.schibsted.spain.barista.internal.matcher.ListViewItemCountAssertion
 import com.schibsted.spain.barista.internal.matcher.RecyclerViewItemCountAssertion
 import org.hamcrest.CoreMatchers
@@ -29,10 +30,10 @@ object BaristaListAssertions {
         val listViewMatcher = findListViewMatcher(listId)
 
         try {
-            Espresso.onView(recyclerMatcher).check(RecyclerViewItemCountAssertion(expectedItemCount))
+            Espresso.onView(recyclerMatcher).withFailureHandler(spyFailureHandler).check(RecyclerViewItemCountAssertion(expectedItemCount))
         } catch (noRecyclerMatching: NoMatchingViewException) {
             try {
-                Espresso.onView(listViewMatcher).check(ListViewItemCountAssertion(expectedItemCount))
+                Espresso.onView(listViewMatcher).withFailureHandler(spyFailureHandler).check(ListViewItemCountAssertion(expectedItemCount))
             } catch (listViewError: Throwable) {
                 spyFailureHandler.resendLastError("Item count mismatch on ListView. Expected $expectedItemCount items in the list.")
             }

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/ListViewAssertionTest.kt
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/ListViewAssertionTest.kt
@@ -5,6 +5,7 @@ import android.support.test.rule.ActivityTestRule
 import android.support.test.runner.AndroidJUnit4
 import com.schibsted.spain.barista.assertion.BaristaListAssertions.assertDisplayedAtPosition
 import com.schibsted.spain.barista.assertion.BaristaListAssertions.assertListItemCount
+import com.schibsted.spain.barista.internal.failurehandler.BaristaException
 import junit.framework.AssertionFailedError
 import org.junit.Rule
 import org.junit.Test
@@ -22,6 +23,13 @@ class ListViewAssertionTest {
         openSimpleListActivity()
         val expectedListLength = ListsActivity.FRUITS.size
         assertListItemCount(R.id.listview, expectedListLength)
+    }
+
+    @Test(expected = BaristaException::class)
+    fun shouldFailWhenNumberOfEntriesInListViewDoesNotMatchExpected() {
+        openSimpleListActivity()
+        val expectedListLength = ListsActivity.FRUITS.size
+        assertListItemCount(R.id.listview, expectedListLength + 1)
     }
 
     @Test


### PR DESCRIPTION
Fixes bug that caused all calls to `assertListItemCount` to succeed.

Added test for this use case.