### PR TITLE
Add Schibsted code style

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Barista makes developing UI test faster, easier and more predictable. Built on t
       - [Dealing with Flaky tests](#dealing-with-flaky-tests)
       - [One rule to rule them all](#one-rule-to-rule-them-all)
   - [Magic that Barista does for you](#magic-that-barista-does-for-you)
+  - [Contributing](#contributing)
   - [License](#license)
 
 # Download
@@ -353,6 +354,13 @@ In order to speed up testing, Barista keeps in mind some considerations.
 - **Scrolls when needed**: Interacting with Espresso in a `ScrollView` requires you to scroll to each view, which sometimes doesn't work the first time. Also trying to scroll outside a `ScrollView` produces an `Exception`, forcing you to change the test depending on the layout. To keep tests simpler, Barista scrolls automatically before interacting with any `View`, and only does it if needed.
 - **Scrolls on all views**: Barista scrolls on all scrollable views, including `NestedScrollView`. Espresso only handles `ScrollView` and `HorizontalScrollView`, so people need to open questions on [StackOverflow like this](https://stackoverflow.com/questions/35272953/espresso-scrolling-not-working-when-nestedscrollview-or-recyclerview-is-in-coor). Or... just use **Barista**.
 - **Just interacts with displayed Views**: Interacting with `View`s inside a `ViewPager` throws `AmbiguousViewMatcherException`, because the views you interact with will be potentially repeated on different pages. Barista only interacts with displayed widgets, so you can focus on the behavior instead of wasting time on details.
+
+# Contributing
+
+We welcome contributions! If you found a bug or have a feature request, feel free to [open an issue](https://github.com/SchibstedSpain/Barista/issues/new) to discuss it. Remember that bugs reported with a reproducible test are more likely to be investigated and fixed. You can also submit a Pull Request.
+
+## Formatting
+We use our company's IntelliJ code style for the project, which is very similar to the official Kotlin Android code style. When submitting code please make sure you use the proper format. You can install the code style into Android Studio by running the script in `./config/androidstudio/install-codestyle.sh`. Then restart Android Studio and pick the "SchibstedAndroid" schema in preferences.
 
 # License
 **[Apache License, Version 2.0 (the "License")](LICENSE.md)**

--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ In order to speed up testing, Barista keeps in mind some considerations.
 We welcome contributions! If you found a bug or have a feature request, feel free to [open an issue](https://github.com/SchibstedSpain/Barista/issues/new) to discuss it. Remember that bugs reported with a reproducible test are more likely to be investigated and fixed. You can also submit a Pull Request.
 
 ## Formatting
-We use our company's IntelliJ code style for the project, which is very similar to the official Kotlin Android code style. When submitting code please make sure you use the proper format. You can install the code style into Android Studio by running the script in `./config/androidstudio/install-codestyle.sh`. Then restart Android Studio and pick the "SchibstedAndroid" schema in preferences.
+We use our company's IntelliJ code style for the project, which is very similar to the official Kotlin Android code style. When submitting code please make sure you use the proper format. You can install the code style into Android Studio by running the script in `./config/androidstudio/install-codestyle.sh`. Then restart Android Studio and pick the "BaristaAndroid" schema in preferences.
 
 # License
 **[Apache License, Version 2.0 (the "License")](LICENSE.md)**

--- a/config/androidstudio/codestyle/BaristaAndroid.xml
+++ b/config/androidstudio/codestyle/BaristaAndroid.xml
@@ -1,4 +1,4 @@
-<code_scheme name="SchibstedAndroid" version="173">
+<code_scheme name="BaristaAndroid" version="173">
     <option name="USE_SAME_INDENTS" value="true" />
     <option name="IGNORE_SAME_INDENTS_FOR_LANGUAGES" value="true" />
     <option name="OTHER_INDENT_OPTIONS">

--- a/config/androidstudio/codestyle/SchibstedAndroid.xml
+++ b/config/androidstudio/codestyle/SchibstedAndroid.xml
@@ -1,0 +1,435 @@
+<code_scheme name="SchibstedAndroid" version="173">
+    <option name="USE_SAME_INDENTS" value="true" />
+    <option name="IGNORE_SAME_INDENTS_FOR_LANGUAGES" value="true" />
+    <option name="OTHER_INDENT_OPTIONS">
+        <value>
+            <option name="INDENT_SIZE" value="2" />
+            <option name="CONTINUATION_INDENT_SIZE" value="4" />
+            <option name="TAB_SIZE" value="2" />
+        </value>
+    </option>
+    <option name="RIGHT_MARGIN" value="140" />
+    <option name="LINE_COMMENT_AT_FIRST_COLUMN" value="false" />
+    <option name="BLOCK_COMMENT_AT_FIRST_COLUMN" value="false" />
+    <option name="KEEP_FIRST_COLUMN_COMMENT" value="false" />
+    <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
+    <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+    <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="0" />
+    <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
+    <option name="ALIGN_MULTILINE_FOR" value="false" />
+    <option name="SPACE_WITHIN_ARRAY_INITIALIZER_BRACES" value="true" />
+    <option name="SPACE_BEFORE_ARRAY_INITIALIZER_LBRACE" value="true" />
+    <option name="CALL_PARAMETERS_WRAP" value="1" />
+    <option name="METHOD_PARAMETERS_WRAP" value="1" />
+    <option name="RESOURCE_LIST_WRAP" value="1" />
+    <option name="EXTENDS_LIST_WRAP" value="1" />
+    <option name="THROWS_LIST_WRAP" value="1" />
+    <option name="EXTENDS_KEYWORD_WRAP" value="1" />
+    <option name="THROWS_KEYWORD_WRAP" value="1" />
+    <option name="METHOD_CALL_CHAIN_WRAP" value="5" />
+    <option name="BINARY_OPERATION_WRAP" value="5" />
+    <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
+    <option name="TERNARY_OPERATION_WRAP" value="1" />
+    <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
+    <option name="FOR_STATEMENT_WRAP" value="1" />
+    <option name="ARRAY_INITIALIZER_WRAP" value="1" />
+    <option name="ASSIGNMENT_WRAP" value="1" />
+    <option name="WRAP_COMMENTS" value="true" />
+    <option name="ASSERT_STATEMENT_WRAP" value="1" />
+    <option name="IF_BRACE_FORCE" value="1" />
+    <option name="DOWHILE_BRACE_FORCE" value="1" />
+    <option name="WHILE_BRACE_FORCE" value="1" />
+    <option name="METHOD_ANNOTATION_WRAP" value="1" />
+    <option name="CLASS_ANNOTATION_WRAP" value="1" />
+    <option name="FIELD_ANNOTATION_WRAP" value="1" />
+    <option name="PARAMETER_ANNOTATION_WRAP" value="1" />
+    <option name="VARIABLE_ANNOTATION_WRAP" value="1" />
+    <option name="ENUM_CONSTANTS_WRAP" value="1" />
+    <AndroidXmlCodeStyleSettings>
+        <option name="USE_CUSTOM_SETTINGS" value="true" />
+        <option name="LAYOUT_SETTINGS">
+            <value>
+                <option name="INSERT_BLANK_LINE_BEFORE_TAG" value="false" />
+                <option name="INSERT_LINE_BREAK_AFTER_LAST_ATTRIBUTE" value="true" />
+            </value>
+        </option>
+        <option name="MANIFEST_SETTINGS">
+            <value>
+                <option name="INSERT_LINE_BREAK_AFTER_LAST_ATTRIBUTE" value="true" />
+            </value>
+        </option>
+        <option name="VALUE_RESOURCE_FILE_SETTINGS">
+            <value>
+                <option name="WRAP_ATTRIBUTES" value="2" />
+            </value>
+        </option>
+        <option name="OTHER_SETTINGS">
+            <value>
+                <option name="INSERT_LINE_BREAK_AFTER_LAST_ATTRIBUTE" value="true" />
+            </value>
+        </option>
+    </AndroidXmlCodeStyleSettings>
+    <JavaCodeStyleSettings>
+        <option name="CLASS_NAMES_IN_JAVADOC" value="3" />
+        <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
+        <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
+        <option name="PACKAGES_TO_USE_IMPORT_ON_DEMAND">
+            <value />
+        </option>
+        <option name="IMPORT_LAYOUT_TABLE">
+            <value>
+                <package name="" withSubpackages="true" static="false" />
+                <emptyLine />
+                <package name="" withSubpackages="true" static="true" />
+            </value>
+        </option>
+        <option name="JD_ALIGN_PARAM_COMMENTS" value="false" />
+        <option name="JD_ALIGN_EXCEPTION_COMMENTS" value="false" />
+        <option name="JD_P_AT_EMPTY_LINES" value="false" />
+        <option name="JD_DO_NOT_WRAP_ONE_LINE_COMMENTS" value="true" />
+        <option name="JD_KEEP_EMPTY_PARAMETER" value="false" />
+        <option name="JD_KEEP_EMPTY_RETURN" value="false" />
+        <option name="JD_PRESERVE_LINE_FEEDS" value="true" />
+    </JavaCodeStyleSettings>
+    <JetCodeStyleSettings>
+        <option name="PACKAGES_TO_USE_STAR_IMPORTS">
+            <value />
+        </option>
+        <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
+        <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
+        <option name="WRAP_EXPRESSION_BODY_FUNCTIONS" value="1" />
+    </JetCodeStyleSettings>
+    <Objective-C-extensions>
+        <file>
+            <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Import" />
+            <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Macro" />
+            <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Typedef" />
+            <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Enum" />
+            <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Constant" />
+            <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Global" />
+            <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Struct" />
+            <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="FunctionPredecl" />
+            <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Function" />
+        </file>
+        <class>
+            <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Property" />
+            <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Synthesize" />
+            <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="InitMethod" />
+            <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="StaticMethod" />
+            <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="InstanceMethod" />
+            <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="DeallocMethod" />
+        </class>
+        <extensions>
+            <pair source="cpp" header="h" fileNamingConvention="NONE" />
+            <pair source="c" header="h" fileNamingConvention="NONE" />
+        </extensions>
+    </Objective-C-extensions>
+    <XML>
+        <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
+    </XML>
+    <ADDITIONAL_INDENT_OPTIONS fileType="php">
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+        <option name="TAB_SIZE" value="2" />
+    </ADDITIONAL_INDENT_OPTIONS>
+    <ADDITIONAL_INDENT_OPTIONS fileType="scala">
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="2" />
+        <option name="TAB_SIZE" value="2" />
+    </ADDITIONAL_INDENT_OPTIONS>
+    <ADDITIONAL_INDENT_OPTIONS fileType="sql">
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+        <option name="TAB_SIZE" value="2" />
+    </ADDITIONAL_INDENT_OPTIONS>
+    <codeStyleSettings language="CSS">
+        <indentOptions>
+            <option name="INDENT_SIZE" value="2" />
+            <option name="CONTINUATION_INDENT_SIZE" value="4" />
+            <option name="TAB_SIZE" value="2" />
+        </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="Groovy">
+        <option name="KEEP_LINE_BREAKS" value="false" />
+        <option name="KEEP_FIRST_COLUMN_COMMENT" value="false" />
+        <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
+        <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+        <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="0" />
+        <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
+        <option name="ALIGN_MULTILINE_FOR" value="false" />
+        <option name="CALL_PARAMETERS_WRAP" value="1" />
+        <option name="METHOD_PARAMETERS_WRAP" value="1" />
+        <option name="EXTENDS_LIST_WRAP" value="1" />
+        <option name="THROWS_LIST_WRAP" value="1" />
+        <option name="EXTENDS_KEYWORD_WRAP" value="1" />
+        <option name="THROWS_KEYWORD_WRAP" value="1" />
+        <option name="METHOD_CALL_CHAIN_WRAP" value="5" />
+        <option name="BINARY_OPERATION_WRAP" value="1" />
+        <option name="TERNARY_OPERATION_WRAP" value="1" />
+        <option name="FOR_STATEMENT_WRAP" value="1" />
+        <option name="ASSIGNMENT_WRAP" value="1" />
+        <option name="ASSERT_STATEMENT_WRAP" value="1" />
+        <option name="IF_BRACE_FORCE" value="1" />
+        <option name="WHILE_BRACE_FORCE" value="1" />
+        <option name="METHOD_ANNOTATION_WRAP" value="1" />
+        <option name="CLASS_ANNOTATION_WRAP" value="1" />
+        <option name="FIELD_ANNOTATION_WRAP" value="1" />
+        <option name="PARAMETER_ANNOTATION_WRAP" value="1" />
+        <option name="VARIABLE_ANNOTATION_WRAP" value="1" />
+        <indentOptions>
+            <option name="INDENT_SIZE" value="2" />
+            <option name="CONTINUATION_INDENT_SIZE" value="4" />
+            <option name="TAB_SIZE" value="2" />
+        </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="JAVA">
+        <option name="LINE_COMMENT_AT_FIRST_COLUMN" value="false" />
+        <option name="BLOCK_COMMENT_AT_FIRST_COLUMN" value="false" />
+        <option name="KEEP_FIRST_COLUMN_COMMENT" value="false" />
+        <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
+        <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+        <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="0" />
+        <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
+        <option name="ALIGN_MULTILINE_FOR" value="false" />
+        <option name="SPACE_WITHIN_ARRAY_INITIALIZER_BRACES" value="true" />
+        <option name="SPACE_BEFORE_ARRAY_INITIALIZER_LBRACE" value="true" />
+        <option name="CALL_PARAMETERS_WRAP" value="1" />
+        <option name="METHOD_PARAMETERS_WRAP" value="1" />
+        <option name="RESOURCE_LIST_WRAP" value="1" />
+        <option name="EXTENDS_LIST_WRAP" value="1" />
+        <option name="THROWS_LIST_WRAP" value="1" />
+        <option name="EXTENDS_KEYWORD_WRAP" value="1" />
+        <option name="THROWS_KEYWORD_WRAP" value="1" />
+        <option name="METHOD_CALL_CHAIN_WRAP" value="5" />
+        <option name="BINARY_OPERATION_WRAP" value="5" />
+        <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
+        <option name="TERNARY_OPERATION_WRAP" value="1" />
+        <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
+        <option name="FOR_STATEMENT_WRAP" value="1" />
+        <option name="ARRAY_INITIALIZER_WRAP" value="1" />
+        <option name="ARRAY_INITIALIZER_LBRACE_ON_NEXT_LINE" value="true" />
+        <option name="ARRAY_INITIALIZER_RBRACE_ON_NEXT_LINE" value="true" />
+        <option name="ASSIGNMENT_WRAP" value="1" />
+        <option name="ASSERT_STATEMENT_WRAP" value="1" />
+        <option name="IF_BRACE_FORCE" value="1" />
+        <option name="DOWHILE_BRACE_FORCE" value="1" />
+        <option name="WHILE_BRACE_FORCE" value="1" />
+        <option name="CLASS_ANNOTATION_WRAP" value="1" />
+        <option name="FIELD_ANNOTATION_WRAP" value="1" />
+        <option name="PARAMETER_ANNOTATION_WRAP" value="1" />
+        <option name="VARIABLE_ANNOTATION_WRAP" value="1" />
+        <indentOptions>
+            <option name="INDENT_SIZE" value="2" />
+            <option name="CONTINUATION_INDENT_SIZE" value="4" />
+            <option name="TAB_SIZE" value="2" />
+        </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="JSON">
+        <option name="KEEP_LINE_BREAKS" value="false" />
+        <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+    </codeStyleSettings>
+    <codeStyleSettings language="JavaScript">
+        <option name="KEEP_LINE_BREAKS" value="false" />
+        <option name="KEEP_FIRST_COLUMN_COMMENT" value="false" />
+        <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+        <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
+        <option name="ALIGN_MULTILINE_FOR" value="false" />
+        <option name="CALL_PARAMETERS_WRAP" value="1" />
+        <option name="METHOD_PARAMETERS_WRAP" value="1" />
+        <option name="BINARY_OPERATION_WRAP" value="5" />
+        <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
+        <option name="TERNARY_OPERATION_WRAP" value="1" />
+        <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
+        <option name="FOR_STATEMENT_WRAP" value="1" />
+        <option name="ARRAY_INITIALIZER_WRAP" value="1" />
+        <option name="ASSIGNMENT_WRAP" value="1" />
+        <option name="IF_BRACE_FORCE" value="1" />
+        <option name="DOWHILE_BRACE_FORCE" value="1" />
+        <option name="WHILE_BRACE_FORCE" value="1" />
+        <option name="PARENT_SETTINGS_INSTALLED" value="true" />
+        <indentOptions>
+            <option name="INDENT_SIZE" value="2" />
+            <option name="TAB_SIZE" value="2" />
+        </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="XML">
+        <option name="FORCE_REARRANGE_MODE" value="1" />
+        <indentOptions>
+            <option name="INDENT_SIZE" value="2" />
+            <option name="CONTINUATION_INDENT_SIZE" value="4" />
+            <option name="TAB_SIZE" value="2" />
+        </indentOptions>
+        <arrangement>
+            <rules>
+                <section>
+                    <rule>
+                        <match>
+                            <AND>
+                                <NAME>xmlns:android</NAME>
+                                <XML_NAMESPACE>^$</XML_NAMESPACE>
+                            </AND>
+                        </match>
+                    </rule>
+                </section>
+                <section>
+                    <rule>
+                        <match>
+                            <AND>
+                                <NAME>xmlns:.*</NAME>
+                                <XML_NAMESPACE>^$</XML_NAMESPACE>
+                            </AND>
+                        </match>
+                        <order>BY_NAME</order>
+                    </rule>
+                </section>
+                <section>
+                    <rule>
+                        <match>
+                            <AND>
+                                <NAME>.*:id</NAME>
+                                <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                            </AND>
+                        </match>
+                    </rule>
+                </section>
+                <section>
+                    <rule>
+                        <match>
+                            <AND>
+                                <NAME>.*:name</NAME>
+                                <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                            </AND>
+                        </match>
+                    </rule>
+                </section>
+                <section>
+                    <rule>
+                        <match>
+                            <AND>
+                                <NAME>name</NAME>
+                                <XML_NAMESPACE>^$</XML_NAMESPACE>
+                            </AND>
+                        </match>
+                    </rule>
+                </section>
+                <section>
+                    <rule>
+                        <match>
+                            <AND>
+                                <NAME>style</NAME>
+                                <XML_NAMESPACE>^$</XML_NAMESPACE>
+                            </AND>
+                        </match>
+                    </rule>
+                </section>
+                <section>
+                    <rule>
+                        <match>
+                            <AND>
+                                <NAME>.*</NAME>
+                                <XML_NAMESPACE>^$</XML_NAMESPACE>
+                            </AND>
+                        </match>
+                        <order>BY_NAME</order>
+                    </rule>
+                </section>
+                <section>
+                    <rule>
+                        <match>
+                            <AND>
+                                <NAME>.*:layout_width</NAME>
+                                <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                            </AND>
+                        </match>
+                    </rule>
+                </section>
+                <section>
+                    <rule>
+                        <match>
+                            <AND>
+                                <NAME>.*:layout_height</NAME>
+                                <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                            </AND>
+                        </match>
+                    </rule>
+                </section>
+                <section>
+                    <rule>
+                        <match>
+                            <AND>
+                                <NAME>.*:layout_.*</NAME>
+                                <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                            </AND>
+                        </match>
+                        <order>BY_NAME</order>
+                    </rule>
+                </section>
+                <section>
+                    <rule>
+                        <match>
+                            <AND>
+                                <NAME>.*:width</NAME>
+                                <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                            </AND>
+                        </match>
+                        <order>BY_NAME</order>
+                    </rule>
+                </section>
+                <section>
+                    <rule>
+                        <match>
+                            <AND>
+                                <NAME>.*:height</NAME>
+                                <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                            </AND>
+                        </match>
+                        <order>BY_NAME</order>
+                    </rule>
+                </section>
+                <section>
+                    <rule>
+                        <match>
+                            <AND>
+                                <NAME>.*</NAME>
+                                <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                            </AND>
+                        </match>
+                        <order>BY_NAME</order>
+                    </rule>
+                </section>
+                <section>
+                    <rule>
+                        <match>
+                            <AND>
+                                <NAME>.*</NAME>
+                                <XML_NAMESPACE>.*</XML_NAMESPACE>
+                            </AND>
+                        </match>
+                        <order>BY_NAME</order>
+                    </rule>
+                </section>
+            </rules>
+        </arrangement>
+    </codeStyleSettings>
+    <codeStyleSettings language="kotlin">
+        <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
+        <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+        <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="0" />
+        <option name="CALL_PARAMETERS_WRAP" value="1" />
+        <option name="METHOD_PARAMETERS_WRAP" value="5" />
+        <option name="METHOD_PARAMETERS_LPAREN_ON_NEXT_LINE" value="true" />
+        <option name="METHOD_PARAMETERS_RPAREN_ON_NEXT_LINE" value="true" />
+        <option name="EXTENDS_LIST_WRAP" value="1" />
+        <option name="METHOD_CALL_CHAIN_WRAP" value="1" />
+        <option name="WRAP_FIRST_METHOD_IN_CALL_CHAIN" value="true" />
+        <option name="ASSIGNMENT_WRAP" value="1" />
+        <option name="METHOD_ANNOTATION_WRAP" value="0" />
+        <option name="CLASS_ANNOTATION_WRAP" value="0" />
+        <option name="FIELD_ANNOTATION_WRAP" value="1" />
+        <indentOptions>
+            <option name="INDENT_SIZE" value="2" />
+            <option name="CONTINUATION_INDENT_SIZE" value="4" />
+            <option name="TAB_SIZE" value="2" />
+        </indentOptions>
+    </codeStyleSettings>
+</code_scheme>

--- a/config/androidstudio/install-codestyle.sh
+++ b/config/androidstudio/install-codestyle.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Based on Square's codestyle installer (https://github.com/square/java-code-styles/blob/master/install.sh)
+
+echo "Installing Schibsted IntelliJ configs..."
+
+CONFIGS="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+for i in $HOME/Library/Preferences/IntelliJIdea*  \
+         $HOME/Library/Preferences/IdeaIC*        \
+         $HOME/Library/Preferences/AndroidStudio* \
+         $HOME/.IntelliJIdea*/config              \
+         $HOME/.IdeaIC*/config                    \
+         $HOME/.AndroidStudio*/config
+do
+  if [[ -d $i ]]; then
+    # create codestyle folders
+    mkdir -p $i/codestyles
+    # copy xmls
+    cp -frv "$CONFIGS/codestyle"/* $i/codestyles
+  fi
+done
+
+echo "Done."
+echo ""
+echo "Restart IntelliJ and/or AndroidStudio, go to Preferences, Editor, Code Style, and select 'SchibstedAndroid-InfoJobs' as scheme."


### PR DESCRIPTION
I copied our internal code style settings, based on Square and adapted for the Android's official Kotlin style guide.
Also added a little paragraph in the readme about contributing and how to install the code style.

Is this enough? Should we add or change anything else?

Fixes https://github.com/SchibstedSpain/Barista/issues/154