### PR TITLE
Adds assertVisible(Matcher) and assertNotVisible(Matcher) methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,12 +130,16 @@ assertDisplayed("Hello world");
 assertDisplayed(R.string.hello_world);
 assertDisplayed(R.id.button);
 assertDisplayed(R.id.button, "Hello world")
+// you can also pass custom matchers
+assertDisplayed(withTagValue(is("tagName")))
 
 // ...or not?
 assertNotDisplayed("Hello world");
 assertNotDisplayed(R.string.hello_world);
 assertNotDisplayed(R.id.button);
 assertNotDisplayed(R.id.button, "Hello world")
+// you can also pass custom matchers
+assertNotDisplayed(withTagValue(is("tagName")))
 
 // Is this view enabled?
 assertEnabled("Hello world");

--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaVisibilityAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaVisibilityAssertions.kt
@@ -5,15 +5,24 @@ import android.support.annotation.IdRes
 import android.support.annotation.StringRes
 import android.support.test.espresso.Espresso.onView
 import android.support.test.espresso.assertion.ViewAssertions.doesNotExist
-import android.support.test.espresso.matcher.ViewMatchers.*
+import android.support.test.espresso.matcher.ViewMatchers.isDisplayed
+import android.support.test.espresso.matcher.ViewMatchers.withId
+import android.support.test.espresso.matcher.ViewMatchers.withText
+import android.view.View
 import com.schibsted.spain.barista.internal.assertAny
 import com.schibsted.spain.barista.internal.matcher.TextColorMatcher
 import com.schibsted.spain.barista.internal.util.resourceMatcher
 import org.hamcrest.CoreMatchers.containsString
+import org.hamcrest.Matcher
 import org.hamcrest.Matchers.allOf
 import org.hamcrest.Matchers.not
 
 object BaristaVisibilityAssertions {
+
+    @JvmStatic
+    fun assertDisplayed(viewMatcher: Matcher<View>) {
+        viewMatcher.assertAny(isDisplayed())
+    }
 
     @JvmStatic
     fun assertDisplayed(viewId: Int) {
@@ -54,6 +63,12 @@ object BaristaVisibilityAssertions {
     fun assertNotDisplayed(text: String) {
         withText(text).assertAny(not(isDisplayed()))
     }
+
+    @JvmStatic
+    fun assertNotDisplayed(viewMatcher: Matcher<View>) {
+        viewMatcher.assertAny(not(isDisplayed()))
+    }
+
 
     @JvmStatic
     fun assertNotDisplayed(@IdRes viewId: Int, text: String) {

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/assertion/VisibilityAssertionsTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/assertion/VisibilityAssertionsTest.java
@@ -1,11 +1,13 @@
 package com.schibsted.spain.barista.sample.assertion;
 
+import android.support.test.espresso.matcher.ViewMatchers;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
 import com.schibsted.spain.barista.internal.failurehandler.BaristaException;
 import com.schibsted.spain.barista.sample.R;
 import com.schibsted.spain.barista.sample.SomeViewsWithDifferentVisibilitiesActivity;
 import com.schibsted.spain.barista.sample.util.SpyFailureHandlerRule;
+import org.hamcrest.CoreMatchers;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -84,7 +86,7 @@ public class VisibilityAssertionsTest {
     spyFailureHandlerRule.assertEspressoFailures(1);
     assertThat(thrown).isInstanceOf(BaristaException.class)
         .hasMessage("View (with id: com.schibsted.spain.barista.sample:id/visible_view) didn't match condition "
-                + "(with text: is \"This is not the text you are looking for\")");
+            + "(with text: is \"This is not the text you are looking for\")");
   }
 
   @Test
@@ -149,5 +151,70 @@ public class VisibilityAssertionsTest {
     spyFailureHandlerRule.assertEspressoFailures(1);
     assertThat(thrown).isInstanceOf(AssertionError.class)
         .hasMessageContaining("View is present in the hierarchy");
+  }
+
+  @Test
+  public void assertVisibleWithCustomMatcher_Fails_WhenTheMatcherDoesNotFindTheGivenPredicate() {
+    String aTagValueThatDoesNotExistsInTheView = "notPresentTagValue";
+    Throwable thrown = catchThrowable(() ->
+        assertDisplayed(ViewMatchers.withTagValue(CoreMatchers.is(aTagValueThatDoesNotExistsInTheView))));
+
+    spyFailureHandlerRule.assertEspressoFailures(1);
+    assertThat(thrown).isInstanceOf(BaristaException.class)
+        .hasMessage("No view matching (with tag value: is \"notPresentTagValue\") was found");
+  }
+
+  @Test
+  public void assertVisibleWithCustomMatcher_Fails_WhenTheMatcherDoesFindTheGivenPredicateButViewIsHidden() {
+    String aTagValueThatDoesNotExistsInTheView = "presentTagValueHidden";
+    Throwable thrown = catchThrowable(() ->
+        assertDisplayed(ViewMatchers.withTagValue(CoreMatchers.is(aTagValueThatDoesNotExistsInTheView))));
+
+    spyFailureHandlerRule.assertEspressoFailures(1);
+    assertThat(thrown).isInstanceOf(BaristaException.class)
+        .hasMessage("View (with tag value: is \"presentTagValueHidden\") didn't match condition (is displayed on the screen to the user)");
+  }
+
+  @Test
+  public void assertVisibleWithCustomMatcher_Succeeds_WhenTheMatcherMatchesAViewThatIsShown() {
+    String aTagValueThatDoesExistsInTheView = "presentTagValue";
+
+    assertDisplayed(ViewMatchers.withTagValue(CoreMatchers.is(aTagValueThatDoesExistsInTheView)));
+
+    spyFailureHandlerRule.assertNoEspressoFailures();
+  }
+
+  @Test
+  public void assertNotVisibleWithCustomMatcher_Fails_WhenTheMatcherDoesNotFindTheGivenPredicate() {
+    String aTagValueThatDoesNotExistsInTheView = "notPresentTagValue";
+
+    Throwable thrown = catchThrowable(() ->
+        assertNotDisplayed(ViewMatchers.withTagValue(CoreMatchers.is(aTagValueThatDoesNotExistsInTheView))));
+
+    spyFailureHandlerRule.assertEspressoFailures(1);
+    assertThat(thrown).isInstanceOf(BaristaException.class)
+        .hasMessage("No view matching (with tag value: is \"notPresentTagValue\") was found");
+  }
+
+  @Test
+  public void assertVisibleWithCustomMatcher_Succeeds_WhenTheMatcherMatchesAViewThatIsHidden() {
+    String aTagValueThatIsHidden = "presentTagValueHidden";
+
+    assertNotDisplayed(ViewMatchers.withTagValue(CoreMatchers.is(aTagValueThatIsHidden)));
+
+    spyFailureHandlerRule.assertNoEspressoFailures();
+  }
+
+  @Test
+  public void assertVisibleWithCustomMatcher_Fails_WhenTheMatcherMatchesAViewThatIsNotHidden() {
+    String aTagValueThatIsShown = "presentTagValue";
+
+    Throwable thrown = catchThrowable(() ->
+        assertNotDisplayed(ViewMatchers.withTagValue(CoreMatchers.is(aTagValueThatIsShown))));
+
+    spyFailureHandlerRule.assertEspressoFailures(1);
+    String expectedMessage =
+        "View (with tag value: is \"presentTagValue\") didn't match condition (not is displayed on the screen to the user)";
+    assertThat(thrown).isInstanceOf(BaristaException.class).hasMessage(expectedMessage);
   }
 }

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/assertion/VisibilityAssertionsTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/assertion/VisibilityAssertionsTest.java
@@ -1,22 +1,22 @@
 package com.schibsted.spain.barista.sample.assertion;
 
-import android.support.test.espresso.matcher.ViewMatchers;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
 import com.schibsted.spain.barista.internal.failurehandler.BaristaException;
 import com.schibsted.spain.barista.sample.R;
 import com.schibsted.spain.barista.sample.SomeViewsWithDifferentVisibilitiesActivity;
 import com.schibsted.spain.barista.sample.util.SpyFailureHandlerRule;
-import org.hamcrest.CoreMatchers;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static android.support.test.espresso.matcher.ViewMatchers.withTagValue;
 import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertDisplayed;
 import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertNotDisplayed;
 import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertNotExist;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.ThrowableAssert.catchThrowable;
+import static org.hamcrest.CoreMatchers.is;
 
 @RunWith(AndroidJUnit4.class)
 public class VisibilityAssertionsTest {
@@ -157,7 +157,7 @@ public class VisibilityAssertionsTest {
   public void assertVisibleWithCustomMatcher_Fails_WhenTheMatcherDoesNotFindTheGivenPredicate() {
     String aTagValueThatDoesNotExistsInTheView = "notPresentTagValue";
     Throwable thrown = catchThrowable(() ->
-        assertDisplayed(ViewMatchers.withTagValue(CoreMatchers.is(aTagValueThatDoesNotExistsInTheView))));
+        assertDisplayed(withTagValue(is(aTagValueThatDoesNotExistsInTheView))));
 
     spyFailureHandlerRule.assertEspressoFailures(1);
     assertThat(thrown).isInstanceOf(BaristaException.class)
@@ -168,7 +168,7 @@ public class VisibilityAssertionsTest {
   public void assertVisibleWithCustomMatcher_Fails_WhenTheMatcherDoesFindTheGivenPredicateButViewIsHidden() {
     String aTagValueThatDoesNotExistsInTheView = "presentTagValueHidden";
     Throwable thrown = catchThrowable(() ->
-        assertDisplayed(ViewMatchers.withTagValue(CoreMatchers.is(aTagValueThatDoesNotExistsInTheView))));
+        assertDisplayed(withTagValue(is(aTagValueThatDoesNotExistsInTheView))));
 
     spyFailureHandlerRule.assertEspressoFailures(1);
     assertThat(thrown).isInstanceOf(BaristaException.class)
@@ -179,7 +179,7 @@ public class VisibilityAssertionsTest {
   public void assertVisibleWithCustomMatcher_Succeeds_WhenTheMatcherMatchesAViewThatIsShown() {
     String aTagValueThatDoesExistsInTheView = "presentTagValue";
 
-    assertDisplayed(ViewMatchers.withTagValue(CoreMatchers.is(aTagValueThatDoesExistsInTheView)));
+    assertDisplayed(withTagValue(is(aTagValueThatDoesExistsInTheView)));
 
     spyFailureHandlerRule.assertNoEspressoFailures();
   }
@@ -189,7 +189,7 @@ public class VisibilityAssertionsTest {
     String aTagValueThatDoesNotExistsInTheView = "notPresentTagValue";
 
     Throwable thrown = catchThrowable(() ->
-        assertNotDisplayed(ViewMatchers.withTagValue(CoreMatchers.is(aTagValueThatDoesNotExistsInTheView))));
+        assertNotDisplayed(withTagValue(is(aTagValueThatDoesNotExistsInTheView))));
 
     spyFailureHandlerRule.assertEspressoFailures(1);
     assertThat(thrown).isInstanceOf(BaristaException.class)
@@ -200,7 +200,7 @@ public class VisibilityAssertionsTest {
   public void assertVisibleWithCustomMatcher_Succeeds_WhenTheMatcherMatchesAViewThatIsHidden() {
     String aTagValueThatIsHidden = "presentTagValueHidden";
 
-    assertNotDisplayed(ViewMatchers.withTagValue(CoreMatchers.is(aTagValueThatIsHidden)));
+    assertNotDisplayed(withTagValue(is(aTagValueThatIsHidden)));
 
     spyFailureHandlerRule.assertNoEspressoFailures();
   }
@@ -210,7 +210,7 @@ public class VisibilityAssertionsTest {
     String aTagValueThatIsShown = "presentTagValue";
 
     Throwable thrown = catchThrowable(() ->
-        assertNotDisplayed(ViewMatchers.withTagValue(CoreMatchers.is(aTagValueThatIsShown))));
+        assertNotDisplayed(withTagValue(is(aTagValueThatIsShown))));
 
     spyFailureHandlerRule.assertEspressoFailures(1);
     String expectedMessage =

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/assertion/VisibilityAssertionsTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/assertion/VisibilityAssertionsTest.java
@@ -166,9 +166,9 @@ public class VisibilityAssertionsTest {
 
   @Test
   public void assertVisibleWithCustomMatcher_Fails_WhenTheMatcherDoesFindTheGivenPredicateButViewIsHidden() {
-    String aTagValueThatDoesNotExistsInTheView = "presentTagValueHidden";
+    String nonExistingTag = "presentTagValueHidden";
     Throwable thrown = catchThrowable(() ->
-        assertDisplayed(withTagValue(is(aTagValueThatDoesNotExistsInTheView))));
+        assertDisplayed(withTagValue(is(nonExistingTag))));
 
     spyFailureHandlerRule.assertEspressoFailures(1);
     assertThat(thrown).isInstanceOf(BaristaException.class)
@@ -177,19 +177,19 @@ public class VisibilityAssertionsTest {
 
   @Test
   public void assertVisibleWithCustomMatcher_Succeeds_WhenTheMatcherMatchesAViewThatIsShown() {
-    String aTagValueThatDoesExistsInTheView = "presentTagValue";
+    String existingTag = "presentTagValue";
 
-    assertDisplayed(withTagValue(is(aTagValueThatDoesExistsInTheView)));
+    assertDisplayed(withTagValue(is(existingTag)));
 
     spyFailureHandlerRule.assertNoEspressoFailures();
   }
 
   @Test
   public void assertNotVisibleWithCustomMatcher_Fails_WhenTheMatcherDoesNotFindTheGivenPredicate() {
-    String aTagValueThatDoesNotExistsInTheView = "notPresentTagValue";
+    String nonExistingTag = "notPresentTagValue";
 
     Throwable thrown = catchThrowable(() ->
-        assertNotDisplayed(withTagValue(is(aTagValueThatDoesNotExistsInTheView))));
+        assertNotDisplayed(withTagValue(is(nonExistingTag))));
 
     spyFailureHandlerRule.assertEspressoFailures(1);
     assertThat(thrown).isInstanceOf(BaristaException.class)
@@ -198,19 +198,19 @@ public class VisibilityAssertionsTest {
 
   @Test
   public void assertVisibleWithCustomMatcher_Succeeds_WhenTheMatcherMatchesAViewThatIsHidden() {
-    String aTagValueThatIsHidden = "presentTagValueHidden";
+    String hiddenTag = "presentTagValueHidden";
 
-    assertNotDisplayed(withTagValue(is(aTagValueThatIsHidden)));
+    assertNotDisplayed(withTagValue(is(hiddenTag)));
 
     spyFailureHandlerRule.assertNoEspressoFailures();
   }
 
   @Test
   public void assertVisibleWithCustomMatcher_Fails_WhenTheMatcherMatchesAViewThatIsNotHidden() {
-    String aTagValueThatIsShown = "presentTagValue";
+    String shownTag = "presentTagValue";
 
     Throwable thrown = catchThrowable(() ->
-        assertNotDisplayed(withTagValue(is(aTagValueThatIsShown))));
+        assertNotDisplayed(withTagValue(is(shownTag))));
 
     spyFailureHandlerRule.assertEspressoFailures(1);
     String expectedMessage =

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -8,12 +8,14 @@
       android:id="@+id/visible_view"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
+      android:tag="presentTagValue"
       android:text="@string/hello_world"/>
   <TextView
       android:id="@+id/repeated_view_1_gone"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:visibility="gone"
+      android:tag="presentTagValueHidden"
       android:text="@string/repeated"
       />
   <TextView


### PR DESCRIPTION
Related to #224 

This is also a subset of: #266

Adds 2 new methods for BaristaVisibilityAssertions that allows users to assertTheVisibility of anything using Espresso Matchers.

*Next steps* Add other methods to check the existence of views using Matchers (assertExist/assertNotExist)