### PR TITLE
Add BaristaClickableAssertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,11 +167,21 @@ assertUnchecked("Unchecked checkbox");
 assertUnchecked(R.string.unchecked_checkbox);
 assertUnchecked(R.id.unchecked_checkbox);
 
+// Is this view clickable?
+assertClickable("Hello world")
+assertClickable(R.string.hello_world)
+assertClickable(R.id.button)
+
+// ...or not?
+assertNotClickable("Hello world")
+assertNotClickable(R.string.hello_world)
+assertNotClickable(R.id.button)
+
 // Does this view have the focus?
 assertFocused(R.id.focused_view)
 assertFocused("Button")
 
-// ... or not?
+// ...or not?
 assertNotFocused(R.id.focused_view)
 assertNotFocused("Button")
 

--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaClickableAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaClickableAssertions.kt
@@ -1,0 +1,31 @@
+package com.schibsted.spain.barista.assertion
+
+import android.support.annotation.IdRes
+import android.support.test.espresso.matcher.ViewMatchers.withText
+import android.support.test.espresso.matcher.ViewMatchers.isClickable
+import com.schibsted.spain.barista.internal.assertAny
+import com.schibsted.spain.barista.internal.util.resourceMatcher
+import org.hamcrest.Matchers.not
+
+object BaristaClickableAssertions {
+
+  @JvmStatic
+  fun assertClickable(@IdRes resId: Int) {
+    resId.resourceMatcher().assertAny(isClickable())
+  }
+
+  @JvmStatic
+  fun assertClickable(text: String) {
+    withText(text).assertAny(isClickable())
+  }
+
+  @JvmStatic
+  fun assertNotClickable(@IdRes resId: Int) {
+    resId.resourceMatcher().assertAny(not(isClickable()))
+  }
+
+  @JvmStatic
+  fun assertNotClickable(text: String) {
+    withText(text).assertAny(not(isClickable()))
+  }
+}

--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaClickableAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaClickableAssertions.kt
@@ -1,8 +1,7 @@
 package com.schibsted.spain.barista.assertion
 
-import android.support.annotation.IdRes
-import android.support.test.espresso.matcher.ViewMatchers.withText
 import android.support.test.espresso.matcher.ViewMatchers.isClickable
+import android.support.test.espresso.matcher.ViewMatchers.withText
 import com.schibsted.spain.barista.internal.assertAny
 import com.schibsted.spain.barista.internal.util.resourceMatcher
 import org.hamcrest.Matchers.not
@@ -10,7 +9,7 @@ import org.hamcrest.Matchers.not
 object BaristaClickableAssertions {
 
   @JvmStatic
-  fun assertClickable(@IdRes resId: Int) {
+  fun assertClickable(resId: Int) {
     resId.resourceMatcher().assertAny(isClickable())
   }
 
@@ -20,7 +19,7 @@ object BaristaClickableAssertions {
   }
 
   @JvmStatic
-  fun assertNotClickable(@IdRes resId: Int) {
+  fun assertNotClickable(resId: Int) {
     resId.resourceMatcher().assertAny(not(isClickable()))
   }
 

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertionsTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertionsTest.java
@@ -15,6 +15,8 @@ import static com.schibsted.spain.barista.assertion.BaristaBackgroundAssertions.
 import static com.schibsted.spain.barista.assertion.BaristaBackgroundAssertions.assertHasNoBackground;
 import static com.schibsted.spain.barista.assertion.BaristaCheckedAssertions.assertChecked;
 import static com.schibsted.spain.barista.assertion.BaristaCheckedAssertions.assertUnchecked;
+import static com.schibsted.spain.barista.assertion.BaristaClickableAssertions.assertClickable;
+import static com.schibsted.spain.barista.assertion.BaristaClickableAssertions.assertNotClickable;
 import static com.schibsted.spain.barista.assertion.BaristaEnabledAssertions.assertDisabled;
 import static com.schibsted.spain.barista.assertion.BaristaEnabledAssertions.assertEnabled;
 import static com.schibsted.spain.barista.assertion.BaristaFocusedAssertions.assertFocused;
@@ -151,6 +153,58 @@ public class AssertionsTest {
     }
     try {
       assertUnchecked(R.id.button);
+      fail();
+    } catch (Throwable expected) {
+    }
+  }
+
+  @Test
+  public void checkClickableView() {
+    assertClickable(R.id.enabled_button);
+    assertClickable(R.string.enabled_button);
+    assertClickable("Enabled button");
+  }
+
+  @Test
+  public void checkClickableView_breaksWhenNeeded() {
+    try {
+      assertClickable(R.id.disabled_button);
+      fail();
+    } catch (Throwable expected) {
+    }
+    try {
+      assertClickable(R.string.disabled_button);
+      fail();
+    } catch (Throwable expected) {
+    }
+    try {
+      assertClickable("Disabled button");
+      fail();
+    } catch (Throwable expected) {
+    }
+  }
+
+  @Test
+  public void checkNonClickableView() {
+    assertNotClickable(R.id.disabled_button);
+    assertNotClickable(R.string.disabled_button);
+    assertNotClickable("Disabled button");
+  }
+
+  @Test
+  public void checkNonClickableView_breaksWhenNeeded() {
+    try {
+      assertNotClickable(R.id.enabled_button);
+      fail();
+    } catch (Throwable expected) {
+    }
+    try {
+      assertNotClickable(R.string.enabled_button);
+      fail();
+    } catch (Throwable expected) {
+    }
+    try {
+      assertNotClickable("Enabled button");
       fail();
     } catch (Throwable expected) {
     }

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -70,6 +70,8 @@
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:text="@string/enabled_button"
+      android:clickable="true"
+      android:focusable="true"
       />
 
   <Button
@@ -77,6 +79,7 @@
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:enabled="false"
+      android:clickable="false"
       android:text="@string/disabled_button"
       />
 


### PR DESCRIPTION
Adds `BaristaClickableAssertions`, which implements the methods `assertClickable` and `assertNotClickable`. The README was updated accordingly.

**Tests:**

Relevant tests were added to the `AssertionsTest` Java class.

I have used the existing Button views in `SomeViewsWithDifferentVisibilitiesActivity`, adding the property `clickable` to them; let me know if new views are preferred/needed.