### PR TITLE
Assertion for TextInputLayout Text Helper Hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,12 @@ assertError(R.id.edittext, R.string.error);
 assertError(R.id.edittext, "Error message");
 ```
 
+#### Check TextInputLayout's helper text
+```java
+assertHelperText(R.id.textinputlayout, R.string.helper_text);
+assertHelperText(R.id.textinputlayout, "Helper text");
+```
+
 #### Check if text on screen contains given text
 ```java
 assertContains("text");

--- a/README.md
+++ b/README.md
@@ -267,10 +267,10 @@ assertError(R.id.edittext, R.string.error);
 assertError(R.id.edittext, "Error message");
 ```
 
-#### Check TextInputLayout's helper text
+#### Check TextInputLayout's assistive helper text
 ```java
-assertHelperText(R.id.textinputlayout, R.string.helper_text);
-assertHelperText(R.id.textinputlayout, "Helper text");
+assertAssistiveText(R.id.textinputlayout, R.string.helper_text);
+assertAssistiveText(R.id.textinputlayout, "Helper text");
 ```
 
 #### Check if text on screen contains given text

--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaAssistiveTextAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaAssistiveTextAssertions.kt
@@ -11,27 +11,27 @@ import org.hamcrest.Description
 import org.hamcrest.Matcher
 import org.hamcrest.TypeSafeMatcher
 
-object BaristaHelperTextAssertions {
+object BaristaAssistiveTextAssertions {
   @JvmStatic
-  fun assertHelperText(@IdRes viewId: Int, @StringRes text: Int) {
+  fun assertAssitiveText(@IdRes viewId: Int, @StringRes text: Int) {
     val resourceString = InstrumentationRegistry.getTargetContext().resources.getString(text)
-    assertHelperText(viewId, resourceString)
+    assertAssitiveText(viewId, resourceString)
   }
 
   @JvmStatic
-  fun assertHelperText(@IdRes viewId: Int, text: String) {
-    ViewMatchers.withId(viewId).assertAny(matchError(text))
+  fun assertAssitiveText(@IdRes viewId: Int, text: String) {
+    ViewMatchers.withId(viewId).assertAny(matchAssistiveText(text))
   }
 
-  private fun matchError(expectedHelperText: String): Matcher<View> {
+  private fun matchAssistiveText(expectedAssistiveText: String): Matcher<View> {
     return object : TypeSafeMatcher<View>() {
       override fun describeTo(description: Description) {
-        description.appendText("with helper text: ").appendText(expectedHelperText)
+        description.appendText("with helper text: ").appendText(expectedAssistiveText)
       }
 
       override fun matchesSafely(item: View): Boolean {
         return when (item) {
-          is TextInputLayout -> expectedHelperText == item.helperText.toString()
+          is TextInputLayout -> expectedAssistiveText == item.helperText.toString()
           else -> {
             throw UnsupportedOperationException("View of class ${item.javaClass.simpleName} not supported")
           }

--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaHelperTextAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaHelperTextAssertions.kt
@@ -1,0 +1,42 @@
+package com.schibsted.spain.barista.assertion
+
+import android.view.View
+import androidx.annotation.IdRes
+import androidx.annotation.StringRes
+import androidx.test.InstrumentationRegistry
+import androidx.test.espresso.matcher.ViewMatchers
+import com.google.android.material.textfield.TextInputLayout
+import com.schibsted.spain.barista.internal.assertAny
+import org.hamcrest.Description
+import org.hamcrest.Matcher
+import org.hamcrest.TypeSafeMatcher
+
+object BaristaHelperTextAssertions {
+  @JvmStatic
+  fun assertHelperText(@IdRes viewId: Int, @StringRes text: Int) {
+    val resourceString = InstrumentationRegistry.getTargetContext().resources.getString(text)
+    assertHelperText(viewId, resourceString)
+  }
+
+  @JvmStatic
+  fun assertHelperText(@IdRes viewId: Int, text: String) {
+    ViewMatchers.withId(viewId).assertAny(matchError(text))
+  }
+
+  private fun matchError(expectedHelperText: String): Matcher<View> {
+    return object : TypeSafeMatcher<View>() {
+      override fun describeTo(description: Description) {
+        description.appendText("with helper text: ").appendText(expectedHelperText)
+      }
+
+      override fun matchesSafely(item: View): Boolean {
+        return when (item) {
+          is TextInputLayout -> expectedHelperText == item.helperText.toString()
+          else -> {
+            throw UnsupportedOperationException("View of class ${item.javaClass.simpleName} not supported")
+          }
+        }
+      }
+    }
+  }
+}

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/HelperTextTest.kt
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/HelperTextTest.kt
@@ -2,7 +2,7 @@ package com.schibsted.spain.barista.sample
 
 import androidx.test.rule.ActivityTestRule
 import androidx.test.runner.AndroidJUnit4
-import com.schibsted.spain.barista.assertion.BaristaHelperTextAssertions.assertHelperText
+import com.schibsted.spain.barista.assertion.BaristaAssistiveTextAssertions.assertAssitiveText
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -15,11 +15,11 @@ class HelperTextTest {
 
   @Test
   fun assertHelperTextByString() {
-    assertHelperText(R.id.texthelper_inputlayout, "This is a sample helper text")
+    assertAssitiveText(R.id.texthelper_inputlayout, "This is a sample helper text")
   }
 
   @Test
   fun assertHelperTextByResource() {
-    assertHelperText(R.id.texthelper_inputlayout, R.string.text_helper_text)
+    assertAssitiveText(R.id.texthelper_inputlayout, R.string.text_helper_text)
   }
 }

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/HelperTextTest.kt
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/HelperTextTest.kt
@@ -1,0 +1,25 @@
+package com.schibsted.spain.barista.sample
+
+import androidx.test.rule.ActivityTestRule
+import androidx.test.runner.AndroidJUnit4
+import com.schibsted.spain.barista.assertion.BaristaHelperTextAssertions.assertHelperText
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class HelperTextTest {
+
+  @get:Rule
+  var activityRule = ActivityTestRule(HintAndErrorActivity::class.java)
+
+  @Test
+  fun assertHelperTextByString() {
+    assertHelperText(R.id.texthelper_inputlayout, "This is a sample helper text")
+  }
+
+  @Test
+  fun assertHelperTextByResource() {
+    assertHelperText(R.id.texthelper_inputlayout, R.string.text_helper_text)
+  }
+}

--- a/sample/src/main/res/layout/activity_hintanderrortext.xml
+++ b/sample/src/main/res/layout/activity_hintanderrortext.xml
@@ -2,6 +2,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
               android:layout_width="match_parent"
               android:layout_height="match_parent"
+              xmlns:app="http://schemas.android.com/apk/res-auto"
               android:orientation="vertical"
               android:padding="16dp"
     >
@@ -38,4 +39,20 @@
       android:layout_height="wrap_content"
       android:hint="@string/hintanderror_edittext_hint"
       />
+
+  <com.google.android.material.textfield.TextInputLayout
+      android:id="@+id/texthelper_inputlayout"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:hint="@string/hintanderror_inputedittext_hint"
+      app:helperTextEnabled="true"
+      app:helperText="@string/text_helper_text"
+      >
+
+    <com.google.android.material.textfield.TextInputEditText
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        />
+
+  </com.google.android.material.textfield.TextInputLayout>
 </LinearLayout>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -27,6 +27,9 @@
   <string name="hintanderror_edittext_hint">EditText hint</string>
   <string name="hintanderror_edittext_error">EditText error</string>
 
+  <string name="text_helper_hint">TextInputLayout text helper hint</string>
+  <string name="text_helper_text">This is a sample helper text</string>
+
   <string name="avocado">Avocado</string>
   <string name="bilberry">Bilberry</string>
   <string name="tamarind">Tamarind</string>
@@ -35,5 +38,7 @@
   <string name="not_there">NotThere</string>
   <string name="missing">Missing</string>
   <string name="this_text_must_not_be_displayed">This text must not be displayed on the view</string>
+
+
 
 </resources>


### PR DESCRIPTION
This commit will add new assertion for TextInputLayout's helper text 

- Created feature request: https://github.com/SchibstedSpain/Barista/issues/302
- Implemented a new class for asserting the helper text from the TextInputLayout
- Added Android tests to demonstrate the behaviour
- Added example to an existing layout file activity_hintanderrortext.xml
- Updated README for documentation for implementation details