### PR TITLE
added support for string resource id in contains assertion

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,11 +270,15 @@ assertError(R.id.edittext, "Error message");
 #### Check if text on screen contains given text
 ```java
 assertContains("text");
+assertContains(R.string.text);
 assertContains(R.id.textview, "text");
+assertContains(R.id.textview, R.string.text);
 
 // ...or not?
 assertNotContains("text");
+assertNotContains(R.string.text);
 assertNotContains(R.id.textview, "text");
+assertNotContains(R.id.textview, R.string.text);
 ```
 
 #### Check text is given color

--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaVisibilityAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaVisibilityAssertions.kt
@@ -9,6 +9,7 @@ import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import android.view.View
+import androidx.test.platform.app.InstrumentationRegistry
 import com.schibsted.spain.barista.internal.assertAny
 import com.schibsted.spain.barista.internal.matcher.TextColorMatcher
 import com.schibsted.spain.barista.internal.util.resourceMatcher
@@ -85,8 +86,20 @@ object BaristaVisibilityAssertions {
   }
 
   @JvmStatic
+  fun assertContains(@StringRes stringId: Int) {
+    val resourceText = InstrumentationRegistry.getInstrumentation().targetContext.getString(stringId)
+    assertContains(resourceText)
+  }
+
+  @JvmStatic
   fun assertContains(@IdRes viewId: Int, text: String) {
     viewId.resourceMatcher().assertAny(withText(containsString(text)))
+  }
+
+  @JvmStatic
+  fun assertContains(@IdRes viewId: Int, @StringRes stringId: Int) {
+    val resourceText = InstrumentationRegistry.getInstrumentation().targetContext.getString(stringId)
+    assertContains(viewId, resourceText)
   }
 
   @JvmStatic
@@ -95,8 +108,20 @@ object BaristaVisibilityAssertions {
   }
 
   @JvmStatic
+  fun assertNotContains(@StringRes stringId: Int) {
+    val resourceText = InstrumentationRegistry.getInstrumentation().targetContext.getString(stringId)
+    assertNotContains(resourceText)
+  }
+
+  @JvmStatic
   fun assertNotContains(@IdRes resId: Int, text: String) {
     onView(allOf(withId(resId), withText(containsString(text)))).check(doesNotExist())
+  }
+
+  @JvmStatic
+  fun assertNotContains(@IdRes resId: Int, @StringRes stringId: Int) {
+    val resourceText = InstrumentationRegistry.getInstrumentation().targetContext.getString(stringId)
+    assertNotContains(resId, resourceText)
   }
 
   @JvmStatic

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertionsTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/AssertionsTest.java
@@ -331,6 +331,7 @@ public class AssertionsTest {
   @Test
   public void checkTextViewContainsText_withViewId() {
     assertContains(R.id.enabled_button, "Enabled");
+    assertContains(R.string.enabled);
   }
 
   @Test(expected = BaristaException.class)
@@ -338,9 +339,15 @@ public class AssertionsTest {
     assertContains(R.id.enabled_button, "Disabled");
   }
 
+  @Test(expected = BaristaException.class)
+  public void checkTextViewContainsResourceText_withViewId_failsWhenNeeded() {
+    assertContains(R.id.enabled_button, R.string.unexising_text);
+  }
+
   @Test
   public void checkTextViewContainsText_withoutViewId() {
     assertContains("Enabled");
+    assertContains(R.string.enabled);
   }
 
   @Test(expected = BaristaException.class)
@@ -348,9 +355,15 @@ public class AssertionsTest {
     assertContains("unexisting text");
   }
 
+  @Test(expected = BaristaException.class)
+  public void checkTextViewContainsResourceText_withoutViewId_failsWhenNeeded() {
+    assertContains(R.string.unexising_text);
+  }
+
   @Test
   public void checkTextViewDoesntContainsText_withViewId() {
     assertNotContains(R.id.enabled_button, "unexisting text");
+    assertNotContains(R.id.enabled_button, R.string.unexising_text);
   }
 
   @Test(expected = AssertionFailedError.class)
@@ -361,10 +374,16 @@ public class AssertionsTest {
   @Test
   public void checkTextViewDoesntContainsText_withoutViewId() {
     assertNotContains("unexisting text");
+    assertNotContains(R.string.unexising_text);
   }
 
   @Test(expected = AssertionFailedError.class)
   public void checkTextViewDoesntContainsText_withoutViewId_failsWhenNeeded() {
     assertNotContains("Enabled");
+  }
+
+  @Test(expected = AssertionFailedError.class)
+  public void checkTextViewDoesntContainsResourceText_withoutViewId_failsWhenNeeded() {
+    assertNotContains(R.string.enabled);
   }
 }

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -35,5 +35,7 @@
   <string name="not_there">NotThere</string>
   <string name="missing">Missing</string>
   <string name="this_text_must_not_be_displayed">This text must not be displayed on the view</string>
+  <string name="enabled">Enabled</string>
+  <string name="unexising_text">unexisting text</string>
 
 </resources>


### PR DESCRIPTION
This PR is for feature request #292 
- added `assertContains()` & `assertNotContains()` methods with string resource id
- updated tests
- updated readme