### PR TITLE
Remove references to the outdated version 2

### DIFF
--- a/MIGRATION-2.md
+++ b/MIGRATION-2.md
@@ -1,6 +1,6 @@
-# Migration guide from Barista 1.x to 2.0
+# Migration guide from Barista 1.x
 
-You just updated Barista dependency from 1.x to 2.0 and everything is in red?
+You just updated Barista dependency from 1.x and everything is in red?
 We did some breaking changes to improve our public API, and that's why we increased our major version.
 
 But fear not, here are a list of breaking changes and how to solve them:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Barista makes developing UI test faster, easier and more predictable. Built on t
 
 # Download
 
-_Psst, hey. Migrating to Barista 2? [Check out this guide](MIGRATION-2.md) to help you with the transition._
+_Psst, hey. Migrating from Barista 1.x? [Check out this guide](MIGRATION-2.md) to help you with the transition._
 
 Import Barista as a testing dependency:
 ```gradle


### PR DESCRIPTION
We're on version 3, so I've made small changes on the Readme and the Migration md files just to remove references to the outdated version 2

Maybe it's a good time to remove the migration guide... but meanwhile here's a small fix/improvement