### PR TITLE
Use openJdk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: android
-jdk: openjdk8
+jdk: oraclejdk8
 dist: trusty
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: android
 jdk: openjdk8
+dist: trusty
 branches:
   only:
   - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: android
-jdk: oraclejdk8
+jdk: openjdk8
 branches:
   only:
   - master


### PR DESCRIPTION
Travis builds were failing to download jdk 8

It was caused by using `xenial` ubuntu distribution.

Failed build: https://travis-ci.org/SchibstedSpain/Barista/builds/565832037


Moved to `trusty` seems to fix it

https://travis-ci.community/t/error-installing-oraclejdk8-expected-feature-release-number-in-range-of-9-to-14-but-got-8/3766/6