### PR TITLE
Removed `exclude group: 'com.android.support'`

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ Barista makes developing UI test faster, easier and more predictable. Built on t
 Import Barista as a testing dependency:
 ```gradle
 androidTestImplementation('com.schibsted.spain:barista:3.2.0') {
-  exclude group: 'com.android.support'
   exclude group: 'org.jetbrains.kotlin' // Only if you already use Kotlin in your project
 }
 ```


### PR DESCRIPTION
You could add in the AndroidX excludes as well, but it seemed like it was going to make this pretty complicated in onboarding instructions, and not everyone uses those androidx packages.  This is what you could add:
```
exclude group: 'androidx.annotation'
exclude group: 'androidx.legacy'
exclude group: 'androidx.recyclerview'
exclude group: 'androidx.vectordrawable'
```
*Dependencies*
* Old version with support library: https://mvnrepository.com/artifact/com.schibsted.spain/barista/2.10.0
* This version with Android X: https://mvnrepository.com/artifact/com.schibsted.spain/barista/3.2.0